### PR TITLE
fix: default addon label file path so fresh-install Import works (#3)

### DIFF
--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.7.1"
+version: "1.7.2"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",

--- a/src/config/ConfigLoader.js
+++ b/src/config/ConfigLoader.js
@@ -298,17 +298,27 @@ class ConfigLoader {
             config.cover_ramp_duration_ms = options.cover_ramp_duration_sec * 1000;
         }
 
-        // Label file: use explicit setting, or auto-detect from common addon paths
+        // Label file: use explicit setting, auto-detect an existing file, or fall back
+        // to a writable default inside the addon's /config mount. The fallback matters
+        // for fresh installs — without it, the first Import attempt fails with
+        // "No label file path configured" (GitHub issue #3).
+        // /share is not in the auto-detect list because the addon mounts it read-only,
+        // so auto-detecting there would set up a path that can't be written to.
+        const DEFAULT_ADDON_LABEL_FILE = '/config/cgateweb-labels.json';
         if (options.cbus_label_file) {
             config.cbus_label_file = options.cbus_label_file;
         } else {
-            const autoDetectPaths = ['/config/cgateweb-labels.json', '/share/cgate/labels.json', '/data/labels.json'];
+            const autoDetectPaths = [DEFAULT_ADDON_LABEL_FILE, '/data/labels.json'];
             for (const p of autoDetectPaths) {
                 if (fs.existsSync(p)) {
                     config.cbus_label_file = p;
                     this.logger.info(`Auto-detected label file: ${p}`);
                     break;
                 }
+            }
+            if (!config.cbus_label_file) {
+                config.cbus_label_file = DEFAULT_ADDON_LABEL_FILE;
+                this.logger.info(`Using default label file path: ${DEFAULT_ADDON_LABEL_FILE} (will be created on first save)`);
             }
         }
 

--- a/src/webServer.js
+++ b/src/webServer.js
@@ -259,6 +259,12 @@ class WebServer {
     }
 
     async _handleImportLabels(req, res) {
+        if (!this.labelLoader.filePath) {
+            return this._sendJSON(res, 400, {
+                error: 'Label file path not configured. In the Home Assistant add-on, set the "cbus_label_file" option (e.g. "/config/cgateweb-labels.json"). In standalone mode, set cbus_label_file in settings.js.'
+            });
+        }
+
         const contentType = req.headers['content-type'] || '';
         let fileBuffer, filename;
 
@@ -309,7 +315,7 @@ class WebServer {
                 saved: true
             });
         } catch (err) {
-            this._sendJSON(res, 400, { error: `Import failed: ${err.message}` });
+            this._sendJSON(res, 400, { error: err.message });
         }
     }
 

--- a/tests/cbusProjectParser.test.js
+++ b/tests/cbusProjectParser.test.js
@@ -122,6 +122,57 @@ describe('CbusProjectParser', () => {
             expect(result.stats.labelCount).toBe(1);
         });
 
+        it('should parse Toolkit export with child-element Address, TagName, and DLT tags (real-world CLIPSAL.xml shape)', async () => {
+            // Mirrors the structure of a real user-submitted CLIPSAL.xml (GitHub issue #3):
+            // Address and TagName are child elements (not attributes) and groups may include
+            // a <TagsDLT> block. Regression test so this common shape keeps working.
+            const xml = `<?xml version="1.0" encoding="utf-8"?>
+                <Installation>
+                    <DBVersion>2.3</DBVersion>
+                    <Version>1.0</Version>
+                    <Project>
+                        <TagName>DOUG</TagName>
+                        <Address>DOUG</Address>
+                        <Network>
+                            <TagName>Steve</TagName>
+                            <Address>254</Address>
+                            <NetworkNumber>254</NetworkNumber>
+                            <Application>
+                                <TagName>Lighting</TagName>
+                                <Address>56</Address>
+                                <Group>
+                                    <TagName>Main bed blind Southside</TagName>
+                                    <Address>0</Address>
+                                    <TagsDLT>
+                                        <TagDLT>
+                                            <LanguageID>1</LanguageID>
+                                            <FlavourID>1</FlavourID>
+                                            <TagType>TEXT</TagType>
+                                            <TagValue>Southside</TagValue>
+                                        </TagDLT>
+                                    </TagsDLT>
+                                </Group>
+                                <Group>
+                                    <TagName>Bed 2 Large blind</TagName>
+                                    <Address>21</Address>
+                                </Group>
+                            </Application>
+                        </Network>
+                    </Project>
+                </Installation>`;
+
+            const result = await parser.parseXML(xml);
+
+            expect(result.labels).toEqual({
+                '254/56/0': 'Main bed blind Southside',
+                '254/56/21': 'Bed 2 Large blind'
+            });
+            expect(result.networks).toEqual([{ address: '254', name: 'Steve' }]);
+            expect(result.stats.networkCount).toBe(1);
+            expect(result.stats.groupCount).toBe(2);
+            expect(result.stats.labelCount).toBe(2);
+        });
+
         it('should handle empty XML gracefully', async () => {
             const xml = `<?xml version="1.0"?><Root/>`;
             const result = await parser.parseXML(xml);

--- a/tests/config/configLoader.test.js
+++ b/tests/config/configLoader.test.js
@@ -1161,6 +1161,19 @@ describe('ConfigLoader', () => {
             expect(config.cbus_label_file).toBe('/config/cgateweb-labels.json');
         });
 
+        test('should default cbus_label_file to /config/cgateweb-labels.json when unset and no files exist (fresh addon install)', () => {
+            // Only the options file itself exists — no pre-existing label files anywhere.
+            fs.existsSync.mockImplementation((p) => p === '/data/options.json');
+            fs.readFileSync.mockReturnValue(JSON.stringify(baseAddonOptions));
+
+            const config = configLoader.load();
+
+            // Even without an existing label file, the addon must fall back to a writable default
+            // so the first-time "Import" flow can create the file rather than throwing
+            // "No label file path configured". See GitHub issue #3.
+            expect(config.cbus_label_file).toBe('/config/cgateweb-labels.json');
+        });
+
         test('should map ha_discovery_trigger_app_id as string when provided', () => {
             const options = {
                 ...baseAddonOptions,

--- a/tests/webServer.test.js
+++ b/tests/webServer.test.js
@@ -801,6 +801,52 @@ describe('WebServer', () => {
             });
             expect(res.status).toBe(400);
         });
+
+        it('returns 400 with a helpful message when label file path is not configured', async () => {
+            // Reproduces GitHub issue #3: a fresh install with no cbus_label_file configured
+            // should return a clear, actionable error rather than the generic save failure.
+            const noPathLoader = new LabelLoader(null);
+            const noPathServer = new WebServer({
+                port: 0,
+                labelLoader: noPathLoader,
+                allowUnauthenticatedMutations: true,
+                getStatus: () => ({})
+            });
+            await noPathServer.start();
+            const noPathPort = noPathServer._server.address().port;
+
+            try {
+                const res = await new Promise((resolve, reject) => {
+                    const body = Buffer.from('<xml>fake</xml>');
+                    const req = http.request({
+                        hostname: '127.0.0.1',
+                        port: noPathPort,
+                        path: '/api/labels/import',
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/octet-stream',
+                            'Content-Length': body.length
+                        }
+                    }, (response) => {
+                        let data = '';
+                        response.on('data', (chunk) => { data += chunk; });
+                        response.on('end', () => resolve({ status: response.statusCode, body: JSON.parse(data) }));
+                    });
+                    req.on('error', reject);
+                    req.write(body);
+                    req.end();
+                });
+                expect(res.status).toBe(400);
+                expect(res.body.error).toMatch(/label file path not configured/i);
+                expect(res.body.error).toMatch(/cbus_label_file/);
+                // Should NOT be the old raw "No label file path configured" (unhelpful for end users)
+                expect(res.body.error).not.toBe('Import failed: No label file path configured');
+                // Should NOT double-prefix with "Import failed:" (the frontend adds its own prefix)
+                expect(res.body.error).not.toMatch(/^Import failed:/);
+            } finally {
+                await noPathServer.close();
+            }
+        });
     });
 
     describe('_readBody size limit', () => {


### PR DESCRIPTION
## Summary

Fixes #3 — fresh Home Assistant add-on installs could not use the Import tool, failing with `No label file path configured`.

- Add-on mode now defaults `cbus_label_file` to `/config/cgateweb-labels.json` (writable via `config:rw`, persists across updates, visible in HA File Editor) when no option is set and no pre-existing file is found.
- Dropped `/share/cgate/labels.json` from auto-detect — `/share` is mounted read-only, so auto-detecting there guarantees later save failures.
- Import endpoint now short-circuits with a 400 and an actionable message when `filePath` is null (relevant to standalone setups without `cbus_label_file` in `settings.js`).
- Dropped the server-side `Import failed:` prefix that was doubling up with the client-side prefix in toasts.
- Version bumped to 1.7.2.

## Verified

End-to-end with the reporter's sample XML (77 groups):

- Happy path: `POST /api/labels/import` → 200, `imported: 77`, network `{254, "Steve"}`, file saved.
- No-path path: 400 with `Label file path not configured. In the Home Assistant add-on, set the "cbus_label_file" option ...`.

Parser regression test added covering the exact shape of the reporter's file (child-element `<Address>` + `<TagName>` + `<TagsDLT>`).

## Test plan

- [x] `npm test` — 1156 tests pass (37 suites)
- [x] Manual E2E with `/Volumes/share/Backups/CLIPSAL.xml` — 77 labels imported, file created
- [x] Manual E2E with `LabelLoader(null)` — returns the new guidance error
- [ ] CI green on this PR
- [ ] After merge, tag `v1.7.2` to trigger HACS distribution sync