### PR TITLE
refactor: extract entity ID fields to shared helper

### DIFF
--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the C-Gate Web Bridge Home Assistant add-on will be docum
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-04-19
+
+### Fixed
+- **Fresh-install Import failure**: the add-on now falls back to `/config/cgateweb-labels.json` when no `cbus_label_file` option is set and no label file exists at auto-detect paths. Previously, importing a Clipsal project file on a fresh install failed with "No label file path configured". Dropped `/share/cgate/labels.json` from auto-detect since `/share` is mounted read-only.
+- **Standalone Import error message**: when the label file path really is unset (standalone mode), the Import endpoint now returns a 400 with an actionable message pointing at `cbus_label_file` instead of a generic failure.
+- **Doubled toast prefix**: removed the server-side "Import failed: " prefix that was duplicating the client-side prefix in error toasts.
+
+## [1.7.1] - 2026-04-14
+
+### Fixed
+- **Backwards compatibility**: retain `object_id` alongside `default_entity_id` in MQTT discovery payloads so Home Assistant versions prior to 2025.10 continue to work. Unknown keys are silently ignored by both old and new HA versions.
+
+## [1.7.0] - 2026-04-14
+
+### Fixed
+- **HA 2026.4 compatibility**: Home Assistant 2026.4 removed support for the deprecated `object_id` field in MQTT discovery. Replaced with `default_entity_id` (which includes the domain prefix, e.g. `light.kitchen_light`) across `haDiscovery`, `haBridgeDiagnostics`, and `staleDeviceDetector`.
+
 ## [1.6.1] - 2026-04-05
 
 ### Fixed

--- a/src/constants.js
+++ b/src/constants.js
@@ -95,6 +95,11 @@ const HA_ORIGIN_NAME = 'cgateweb';
 const HA_ORIGIN_SW_VERSION = packageJson.version;
 const HA_ORIGIN_SUPPORT_URL = 'https://github.com/dougrathbone/cgateweb';
 
+// HA Discovery entity ID helpers
+function entityIdFields(component, objectId) {
+    return { default_entity_id: `${component}.${objectId}`, object_id: objectId };
+}
+
 // === File Paths ===
 // Default label-file path for Home Assistant add-on installs — /config is mounted
 // read-write and persists across updates.
@@ -193,6 +198,7 @@ module.exports = {
     HA_ORIGIN_NAME,
     HA_ORIGIN_SW_VERSION,
     HA_ORIGIN_SUPPORT_URL,
+    entityIdFields,
 
     // File Paths
     DEFAULT_ADDON_LABEL_FILE,

--- a/src/haBridgeDiagnostics.js
+++ b/src/haBridgeDiagnostics.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { createLogger } = require('./logger');
-const { MQTT_TOPIC_STATUS } = require('./constants');
+const { MQTT_TOPIC_STATUS, entityIdFields } = require('./constants');
 
 const CGATE_VERSION_FILE = '/data/cgate/.version';
 
@@ -72,8 +72,7 @@ class HaBridgeDiagnostics {
             const payload = {
                 name: entity.name,
                 unique_id: `cgateweb_bridge_${entity.key}`,
-                default_entity_id: `${entity.component}.cgateweb_bridge_${entity.key}`,
-                object_id: `cgateweb_bridge_${entity.key}`,
+                ...entityIdFields(entity.component, `cgateweb_bridge_${entity.key}`),
                 state_topic: stateTopic,
                 availability_topic: MQTT_TOPIC_STATUS,
                 payload_available: 'Online',

--- a/src/haDiscovery.js
+++ b/src/haDiscovery.js
@@ -38,7 +38,8 @@ const {
     HA_ORIGIN_SW_VERSION,
     HA_ORIGIN_SUPPORT_URL,
     CGATE_CMD_TREEXML,
-    NEWLINE
+    NEWLINE,
+    entityIdFields
 } = require('./constants');
 
 class HaDiscovery {
@@ -406,7 +407,7 @@ class HaDiscovery {
             const payload = {
                 name: null,
                 unique_id: uniqueId,
-                ...(entityId && { default_entity_id: `${HA_COMPONENT_LIGHT}.${entityId}`, object_id: entityId }),
+                ...(entityId && entityIdFields(HA_COMPONENT_LIGHT, entityId)),
                 state_topic: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/${groupId}/${MQTT_TOPIC_SUFFIX_STATE}`,
                 command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_RAMP}`,
                 brightness_state_topic: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/${groupId}/${MQTT_TOPIC_SUFFIX_LEVEL}`,
@@ -518,7 +519,7 @@ class HaDiscovery {
         const payload = {
             name: null,
             unique_id: uniqueId,
-            ...(entityId && { default_entity_id: `${HA_COMPONENT_CLIMATE}.${entityId}`, object_id: entityId }),
+            ...(entityId && entityIdFields(HA_COMPONENT_CLIMATE, entityId)),
 
             // Current temperature: reported by C-Gate as a status level on this group.
             // Template converts 0-255 C-Bus level to 0-50°C (0.5°C resolution):
@@ -590,7 +591,7 @@ class HaDiscovery {
         const payload = {
             name: null,
             unique_id: uniqueId,
-            ...(entityId && { default_entity_id: `${config.component}.${entityId}`, object_id: entityId }),
+            ...(entityId && entityIdFields(config.component, entityId)),
             state_topic: stateTopic,
             ...(!config.omitCommandTopic && { command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_SWITCH}` }),
             ...config.payloads,
@@ -653,7 +654,7 @@ class HaDiscovery {
         const payload = {
             name: null,
             unique_id: uniqueId,
-            ...(entityId && { default_entity_id: `${HA_COMPONENT_BUTTON}.${entityId}_btn`, object_id: `${entityId}_btn` }),
+            ...(entityId && entityIdFields(HA_COMPONENT_BUTTON, `${entityId}_btn`)),
             command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_TRIGGER}`,
             payload_press: MQTT_STATE_ON,
             qos: 0,
@@ -686,7 +687,7 @@ class HaDiscovery {
         const payload = {
             name: null,
             unique_id: uniqueId,
-            ...(entityId && { default_entity_id: `${HA_COMPONENT_SCENE}.${entityId}_scene`, object_id: `${entityId}_scene` }),
+            ...(entityId && entityIdFields(HA_COMPONENT_SCENE, `${entityId}_scene`)),
             command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_SWITCH}`,
             payload_on: MQTT_STATE_ON,
             qos: 0,

--- a/src/staleDeviceDetector.js
+++ b/src/staleDeviceDetector.js
@@ -1,5 +1,5 @@
 const { createLogger } = require('./logger');
-const { MQTT_TOPIC_STATUS } = require('./constants');
+const { MQTT_TOPIC_STATUS, entityIdFields } = require('./constants');
 
 /**
  * Periodically checks for C-Bus devices that have not reported a state change
@@ -143,8 +143,7 @@ class StaleDeviceDetector {
         const payload = {
             name: 'C-Bus Stale Devices',
             unique_id: 'cgateweb_stale_devices',
-            default_entity_id: 'sensor.cgateweb_stale_devices',
-            object_id: 'cgateweb_stale_devices',
+            ...entityIdFields('sensor', 'cgateweb_stale_devices'),
             state_topic: 'cbus/bridge/stale_devices',
             json_attributes_topic: 'cbus/bridge/stale_devices_detail',
             unit_of_measurement: 'devices',


### PR DESCRIPTION
## Summary

Follow-up to the recent \`default_entity_id\`/\`object_id\` commits (d712c1a, e3ed20d). Extracts the duplicated \`{ default_entity_id, object_id }\` shape into a single \`entityIdFields(component, objectId)\` helper in \`src/constants.js\`.

Replaces 8 inline call sites:
- \`src/haDiscovery.js\`: 5 (light, climate, switch/relay/PIR/sensor, button, scene)
- \`src/haBridgeDiagnostics.js\`: 1 (bridge diagnostics entities)
- \`src/staleDeviceDetector.js\`: 1 (stale devices sensor, converting object-shorthand)

Same emitted MQTT discovery payload; one source of truth for the entity-id convention.

## Test plan

- [x] \`npm test\` — 1156 pass (no behavioural tests changed)
- [ ] CI green