### PR TITLE
fix: do not retain MQTT command topics in HA discovery

### DIFF
--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.11.1"
+version: "1.11.2"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.8.10",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.8.10",
+      "version": "1.11.2",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "mqtt": "^5.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",
@@ -59,7 +59,10 @@
     "check-setup": "node -e \"const { validateSetup } = require('./src/settingsValidator'); let settings; try { settings = require('./settings.js'); } catch(e) { settings = {}; } const result = validateSetup(settings); if (result.isFirstTime) { console.log(result.message); process.exit(1); } if (result.issues.length > 0) { console.log('Issues:', result.issues.join(', ')); } if (result.recommendations.length > 0) { console.log('Recommendations:', result.recommendations.join(', ')); } console.log(result.isValid ? 'Setup looks good!' : 'Please address the issues above');\""
   },
   "jest": {
-    "testPathIgnorePatterns": ["/node_modules/", "/.claude/"],
+    "testPathIgnorePatterns": [
+      "/node_modules/",
+      "/.claude/"
+    ],
     "collectCoverageFrom": [
       "src/**/*.js",
       "index.js",

--- a/src/haDiscovery.js
+++ b/src/haDiscovery.js
@@ -732,7 +732,8 @@ class HaDiscovery {
                 state_value_template: '{{ value }}',
                 brightness_value_template: '{{ value }}',
                 qos: 0,
-                retain: true,
+                // command topics must NOT be retained: a retained command replays to
+                // cgateweb on every reconnect and re-toggles the light (see _createDiscovery).
                 device: {
                     identifiers: [uniqueId],
                     name: finalLabel,
@@ -862,7 +863,7 @@ class HaDiscovery {
             temp_step: 0.5,
 
             qos: 0,
-            retain: true,
+            // command topics must NOT be retained (see _createDiscovery note)
             device: {
                 identifiers: [uniqueId],
                 name: finalLabel,
@@ -931,7 +932,10 @@ class HaDiscovery {
                 tilt_optimistic: false
             }),
             qos: 0,
-            ...(config.isTrigger ? {} : { retain: true }),
+            // NOTE: command topics must NOT be retained. A retained command sits on the
+            // broker and is redelivered to cgateweb on every (re)connect, replaying stale
+            // ON/OFF/RAMP commands that toggle devices unexpectedly. State retention is
+            // handled separately by the read/state publish options, not here.
             ...(config.deviceClass && { device_class: config.deviceClass }),
             device: {
                 identifiers: [uniqueId],

--- a/tests/haDiscovery.test.js
+++ b/tests/haDiscovery.test.js
@@ -270,6 +270,42 @@ describe('HaDiscovery', () => {
             expect(payload.state_closed).toBe('OFF');
         });
 
+        it('should NOT mark light configs as retained (retained commands replay on reconnect and toggle devices)', () => {
+            haDiscovery._publishDiscoveryFromTree('254', MOCK_TREEXML_RESULT_NET254);
+
+            const lightCall = mockPublishFn.mock.calls.find(
+                c => c[0] === 'testhomeassistant/light/cgateweb_254_56_10/config'
+            );
+            expect(lightCall).toBeDefined();
+            const payload = JSON.parse(lightCall[1]);
+            // Sanity: this entity has a command topic, so its commands must never be retained
+            expect(payload.command_topic).toBe('cbus/write/254/56/10/ramp');
+            expect(payload.retain).not.toBe(true);
+        });
+
+        it('should NOT mark switch configs as retained', () => {
+            mockSettings.ha_discovery_switch_app_id = '203';
+            mockSettings.ha_discovery_cover_app_id = null;
+
+            haDiscovery._publishDiscoveryFromTree('254', MOCK_TREEXML_RESULT_NET254);
+
+            const switchCall = mockPublishFn.mock.calls.find(
+                c => c[0] === 'testhomeassistant/switch/cgateweb_254_203_15/config'
+            );
+            expect(switchCall).toBeDefined();
+            expect(JSON.parse(switchCall[1]).retain).not.toBe(true);
+        });
+
+        it('should NOT mark cover configs as retained', () => {
+            haDiscovery._publishDiscoveryFromTree('254', MOCK_TREEXML_RESULT_NET254);
+
+            const coverCall = mockPublishFn.mock.calls.find(
+                c => c[0] === 'testhomeassistant/cover/cgateweb_254_203_15/config'
+            );
+            expect(coverCall).toBeDefined();
+            expect(JSON.parse(coverCall[1]).retain).not.toBe(true);
+        });
+
         it('should publish PIR configs when PIR app ID is configured', () => {
             mockSettings.ha_discovery_pir_app_id = '203';
             mockSettings.ha_discovery_cover_app_id = null;

--- a/tests/hvac.test.js
+++ b/tests/hvac.test.js
@@ -324,6 +324,16 @@ describe('HaDiscovery — HVAC climate entity discovery', () => {
         expect(topics).toContain('homeassistant/climate/cgateweb_254_201_2/config');
     });
 
+    test('climate config does NOT mark commands as retained (retained commands replay on reconnect)', () => {
+        runDiscovery(MOCK_TREE_WITH_HVAC);
+
+        const climateCall = mockPublishFn.mock.calls.find(c =>
+            c[0] === 'homeassistant/climate/cgateweb_254_201_1/config'
+        );
+        expect(climateCall).toBeDefined();
+        expect(JSON.parse(climateCall[1]).retain).not.toBe(true);
+    });
+
     test('climate entity payload has required Home Assistant climate fields', () => {
         runDiscovery(MOCK_TREE_WITH_HVAC);
 


### PR DESCRIPTION
## Problem

C-Bus lights were turning on/off on their own. Root cause: HA discovery payloads set `retain: true` on command-capable entities (light, switch, cover, climate). Home Assistant then publishes **every command** to `cbus/write/...` with the retain flag, so the broker accumulates retained command messages. On each cgateweb/broker reconnect the broker replays them and the bridge re-fires ON/OFF/RAMP, toggling devices unexpectedly. (Observed live: ~70 retained `cbus/write` messages on a production broker.)

## Fix

Command topics must never be retained — state retention is handled separately by the read/state publish options. Removed `retain: true` from:
- light discovery payload
- `_createDiscovery` (switch / cover / relay)
- `_createHvacDiscovery` (climate)

The existing `mqttManager` retained-write guard (a81908f) stays as defense-in-depth.

## Tests

Added tests asserting light/switch/cover/climate configs are not retained. Full suite: 1341 passing, lint clean.

## Deploy note

After deploying, cgateweb republishes discovery without `retain`, so HA stops retaining commands. Any retained `cbus/write` messages already on the broker should be cleared once post-deploy (publish empty retained payload to each).