### PR TITLE
v1.21.0: security panel trouble sensors, Live Events descriptions, restart state resync

### DIFF
--- a/docs/superpowers/plans/2026-07-31-security-trouble-sensors-and-restart-resync.md
+++ b/docs/superpowers/plans/2026-07-31-security-trouble-sensors-and-restart-resync.md
@@ -1,0 +1,751 @@
+# Security Panel Trouble Sensors, Live Events Enrichment and Restart Resync — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the two remaining #42 alpha-feedback items (Live Events enrichment, panel-trouble binary_sensors) and fix #44 (entity state lost across Home Assistant or MQTT broker restarts).
+
+**Architecture:** Three independent slices. (1) An optional `description` field on Live Events SSE entries, rendered by the web UI in place of the level percentage. (2) Seven new panel-wide verbs decoded in `securityDecoder`, tracked by a new stateless-per-network `securityPanelState` module, published as diagnostic `binary_sensor`s on one shared "C-Bus Security Panel" device. (3) A new `stateResyncCoordinator` that re-issues the existing getall plus a security status sync when Home Assistant sends its birth message or the MQTT broker reconnects mid-session.
+
+**Tech Stack:** Node.js (CommonJS), Jest, ESLint, `tsc --noEmit` with `// @ts-check` per file, vanilla JS in `public/index.html`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-07-31-security-trouble-sensors-and-restart-resync-design.md`
+- Target release: **v1.21.0**. Version must be bumped in **both** `package.json` and `homeassistant-addon/config.yaml` (CI `version-sync` job fails otherwise).
+- **No new `config.yaml` options.** All new settings live only in `src/defaultSettings.js`, so `homeassistant-addon/translations/*.yaml` (17 files) stay untouched.
+- `npm test`, `npm run lint` (`--max-warnings 0`) and `npm run typecheck` must all pass before every commit.
+- New files start with `// @ts-check` and `'use strict';`, matching `src/securityEventHandler.js:1-2`.
+- Never include Claude/AI attribution in commit messages.
+- Security app id comes from `settings.cbus_security_app_id`; a falsy value or `'0'` disables all security behaviour.
+- Reuse `src/backoff.js` for any backoff; do not reinvent the formula.
+
+---
+
+### Task 1: Live Events `description` field
+
+**Files:**
+- Modify: `src/securityEventHandler.js` (`_emitEventLog` ~line 308, `_emitSystemEventLog` ~line 270, zone branch ~line 150)
+- Modify: `public/index.html` (`eventMatchesFilter` ~line 1925, `renderEventLog` ~line 1934, `appendEventRow` ~line 1993)
+- Test: `tests/securityEventHandler.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `_emitEventLog(network, application, group, level, type, label = null, description = null)` — trailing optional param, so existing call sites keep working. SSE entry gains `description?: string`. Panel-wide entries now pass `group = null`, and the UI renders such rows as `net/app` with no trailing slash.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `tests/securityEventHandler.test.js`, add to the existing event-log describe block:
+
+```js
+it('includes a description on zone event log entries', () => {
+    const entries = [];
+    const handler = createHandler({ onEventLog: (e) => entries.push(e) });
+    handler.handleLine('# security zone_unsealed //PROJ/254/208/13 #sourceunit=18 OID=');
+    expect(entries[0]).toMatchObject({ group: '13', description: 'Zone unsealed' });
+});
+
+it('includes a description and a null group on panel-wide system entries', () => {
+    const entries = [];
+    const handler = createHandler({ onEventLog: (e) => entries.push(e) });
+    handler.handleLine('# security system_arm //PROJ/254/208 3 #sourceunit=18 OID=');
+    expect(entries[0]).toMatchObject({ group: null, description: 'System armed (Day mode)' });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest tests/securityEventHandler.test.js -t description`
+Expected: FAIL — `description` undefined, `group` is `'0'`.
+
+- [ ] **Step 3: Thread `description` through the handler**
+
+Add the trailing param and pass `_describeSystemEvent(reading)` for system verbs, and a zone-state sentence for zone events:
+
+```js
+_emitEventLog(network, application, group, level, type, label = null, description = null) {
+    if (!this.onEventLog) return;
+    this.onEventLog({
+        ts: Date.now(), network, app: application, group, level, type,
+        ...(label && { label }),
+        ...(description && { description })
+    });
+}
+```
+
+Zone branch: pass `` `Zone ${reading.zoneState}` `` with the state capitalised (`Zone unsealed`). `_emitSystemEventLog`: pass `reading.zone || null` as group and `this._describeSystemEvent(reading)` as description.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest tests/securityEventHandler.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Render it in the UI**
+
+`appendEventRow`: build the address without a trailing slash when there is no group, and carry the description:
+
+```js
+addr: event.group === null || event.group === undefined || event.group === ''
+    ? event.network + '/' + event.app
+    : event.network + '/' + event.app + '/' + event.group,
+description: event.description || '',
+```
+
+`renderEventLog`: replace the value and bar cells with a description-aware pair:
+
+```js
+var valueCell = row.description
+    ? '<td colspan="2">' + esc(row.description) + '</td>'
+    : '<td>' + esc(row.level) + ' (' + pct + '%)</td>' +
+      '<td class="event-bar-cell"><div class="event-bar-bg"><div class="event-bar-fill" style="width:' + pct + '%"></div></div></td>';
+```
+
+`eventMatchesFilter`: add `if (row.description && row.description.toLowerCase().indexOf(f) !== -1) return true;`
+
+- [ ] **Step 6: Full gates**
+
+Run: `npm test && npm run lint && npm run typecheck`
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/securityEventHandler.js public/index.html tests/securityEventHandler.test.js
+git commit -m "fix: describe security events in the Live Events window (#42)"
+```
+
+---
+
+### Task 2: Decode the seven panel-trouble verbs
+
+**Files:**
+- Modify: `src/applicationDecoders/securityDecoder.js` (header docblock, new map above `parseAddress` ~line 66, dispatch before the final `return null` ~line 261)
+- Test: `tests/applicationDecoders/securityDecoder.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `decodeLine` returns `{ kind: 'panel_trouble', network, application, condition, active, verb, detail }` where `condition` is one of `'mains' | 'battery' | 'tamper' | 'panic' | 'line' | 'arm_failed' | 'fire'` and `active` is a boolean. Also exports `PANEL_TROUBLE_CONDITIONS` (array of the seven condition keys, in display order) and `PANEL_TROUBLE_VERBS` (Map of verb → `{condition, active}`).
+
+Note: `arm_failed` and `fire_alarm` currently return `kind: 'arm_failed'` / `'fire_alarm'` with a `detail` (`securityDecoder.js:248`). They now return `kind: 'panel_trouble'` instead, with `active` derived from the `_raised`/`_cleared` detail suffix (bare verb with no detail means raised). `_describeSystemEvent` handling for those two kinds moves accordingly in Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+describe('panel trouble verbs', () => {
+    const cases = [
+        ['mains_failure', 'mains', true],
+        ['mains_restored', 'mains', false],
+        ['low_battery', 'battery', true],
+        ['low_battery_corrected', 'battery', false],
+        ['tamper_on', 'tamper', true],
+        ['tamper_off', 'tamper', false],
+        ['panic_activated', 'panic', true],
+        ['panic_cleared', 'panic', false]
+    ];
+    it.each(cases)('decodes %s', (verb, condition, active) => {
+        const r = decodeLine(`# security ${verb} //MIDSTRM/254/208  #sourceunit=18 OID=`);
+        expect(r).toMatchObject({ kind: 'panel_trouble', network: '254', application: '208', condition, active });
+    });
+
+    it('derives active from the _raised/_cleared detail suffix', () => {
+        expect(decodeLine('# security line_cut_alarm //MIDSTRM/254/208 line_cut_alarm_cleared #sourceunit=18 OID='))
+            .toMatchObject({ condition: 'line', active: false });
+        expect(decodeLine('# security line_cut_alarm //MIDSTRM/254/208 line_cut_alarm_raised #sourceunit=18 OID='))
+            .toMatchObject({ condition: 'line', active: true });
+    });
+
+    it('treats a bare suffix-style verb as raised', () => {
+        expect(decodeLine('# security fire_alarm //MIDSTRM/254/208  #sourceunit=18 OID='))
+            .toMatchObject({ condition: 'fire', active: true });
+    });
+
+    it('still returns null for genuinely unknown verbs', () => {
+        expect(decodeLine('# security some_future_verb //MIDSTRM/254/208 #sourceunit=18 OID=')).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest tests/applicationDecoders/securityDecoder.test.js -t "panel trouble"`
+Expected: FAIL — `decodeLine` returns `null`.
+
+- [ ] **Step 3: Implement**
+
+Add above `parseAddress`:
+
+```js
+/**
+ * Panel-wide trouble conditions. Verb pairs confirmed by the #42 captures
+ * except low_battery, tamper_on and panic_off/panic_cleared, whose raise (or
+ * clear) halves were never captured and are inferred from the naming
+ * convention of the confirmed pairs.
+ */
+const PANEL_TROUBLE_CONDITIONS = ['mains', 'battery', 'tamper', 'panic', 'line', 'arm_failed', 'fire'];
+
+const PANEL_TROUBLE_VERBS = new Map([
+    ['mains_failure', { condition: 'mains', active: true }],
+    ['mains_restored', { condition: 'mains', active: false }],
+    ['low_battery', { condition: 'battery', active: true }],
+    ['low_battery_corrected', { condition: 'battery', active: false }],
+    ['tamper_on', { condition: 'tamper', active: true }],
+    ['tamper_off', { condition: 'tamper', active: false }],
+    ['panic_activated', { condition: 'panic', active: true }],
+    ['panic_off', { condition: 'panic', active: false }],
+    ['panic_cleared', { condition: 'panic', active: false }]
+]);
+
+// Verbs whose active/cleared sense rides a "<verb>_raised" / "<verb>_cleared"
+// detail argument instead of the verb name. A bare verb means raised.
+const PANEL_TROUBLE_DETAIL_VERBS = new Map([
+    ['line_cut_alarm', 'line'],
+    ['arm_failed', 'arm_failed'],
+    ['fire_alarm', 'fire']
+]);
+```
+
+Replace the `arm_failed || fire_alarm` branch (line ~248) with a single dispatch placed before the final `return null`:
+
+```js
+const simple = PANEL_TROUBLE_VERBS.get(verb);
+if (simple) {
+    return { kind: 'panel_trouble', network, application, condition: simple.condition, active: simple.active, verb, detail: null };
+}
+
+const detailCondition = PANEL_TROUBLE_DETAIL_VERBS.get(verb);
+if (detailCondition) {
+    const detail = params.length > 0 ? params.join(' ') : null;
+    const active = !(detail && detail.endsWith('_cleared'));
+    return { kind: 'panel_trouble', network, application, condition: detailCondition, active, verb, detail };
+}
+```
+
+Update the header docblock verb list and export both new constants.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest tests/applicationDecoders/securityDecoder.test.js`
+Expected: PASS. Existing `arm_failed`/`fire_alarm` assertions will fail on `kind` — update them to expect `kind: 'panel_trouble'` with the right `condition`.
+
+- [ ] **Step 5: Full gates and commit**
+
+```bash
+npm test && npm run lint && npm run typecheck
+git add src/applicationDecoders/securityDecoder.js tests/applicationDecoders/securityDecoder.test.js
+git commit -m "feat: decode C-Bus security panel trouble verbs (#42)"
+```
+
+---
+
+### Task 3: `securityPanelState` module
+
+**Files:**
+- Create: `src/securityPanelState.js`
+- Test: `tests/securityPanelState.test.js`
+
+**Interfaces:**
+- Consumes: `PANEL_TROUBLE_CONDITIONS` from Task 2.
+- Produces: class `SecurityPanelState` with
+  - `applyReading(reading) -> Array<{condition: string, active: boolean}>` — returns only *changed* conditions; handles derived clears.
+  - `seedFromStatusReport(reading) -> Array<{condition: string, active: boolean}>`
+  - `initialStates(network) -> Array<{condition: string, active: boolean}>` — all seven, for discovery-time seeding.
+  - `getState(network) -> Object<string, boolean>`
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+const SecurityPanelState = require('../src/securityPanelState');
+
+describe('SecurityPanelState', () => {
+    let state;
+    beforeEach(() => { state = new SecurityPanelState(); });
+
+    it('reports a newly raised condition as changed', () => {
+        expect(state.applyReading({ kind: 'panel_trouble', network: '254', condition: 'mains', active: true }))
+            .toEqual([{ condition: 'mains', active: true }]);
+    });
+
+    it('dedupes a repeated raise', () => {
+        state.applyReading({ kind: 'panel_trouble', network: '254', condition: 'mains', active: true });
+        expect(state.applyReading({ kind: 'panel_trouble', network: '254', condition: 'mains', active: true })).toEqual([]);
+    });
+
+    it('tracks networks independently', () => {
+        state.applyReading({ kind: 'panel_trouble', network: '254', condition: 'mains', active: true });
+        expect(state.applyReading({ kind: 'panel_trouble', network: '200', condition: 'mains', active: true }))
+            .toEqual([{ condition: 'mains', active: true }]);
+    });
+
+    it('clears panic, arm_failed and fire on disarm', () => {
+        for (const condition of ['panic', 'arm_failed', 'fire']) {
+            state.applyReading({ kind: 'panel_trouble', network: '254', condition, active: true });
+        }
+        const cleared = state.applyReading({ kind: 'system_arm', network: '254', mode: 0 });
+        expect(cleared.map((c) => c.condition).sort()).toEqual(['arm_failed', 'fire', 'panic']);
+        expect(cleared.every((c) => c.active === false)).toBe(true);
+    });
+
+    it('clears arm_failed on a successful arm but leaves panic alone', () => {
+        state.applyReading({ kind: 'panel_trouble', network: '254', condition: 'arm_failed', active: true });
+        state.applyReading({ kind: 'panel_trouble', network: '254', condition: 'panic', active: true });
+        expect(state.applyReading({ kind: 'system_arm', network: '254', mode: 1 }))
+            .toEqual([{ condition: 'arm_failed', active: false }]);
+    });
+
+    it('does not report unchanged conditions on disarm', () => {
+        expect(state.applyReading({ kind: 'system_arm', network: '254', mode: 0 })).toEqual([]);
+    });
+
+    it('seeds tamper and panic from a status report', () => {
+        const seeded = state.seedFromStatusReport({
+            kind: 'status_report_1', network: '254', tamperActive: true, panicActive: false
+        });
+        expect(seeded).toEqual([{ condition: 'tamper', active: true }]);
+        expect(state.getState('254').tamper).toBe(true);
+    });
+
+    it('initialStates returns all seven conditions defaulting to inactive', () => {
+        const initial = state.initialStates('254');
+        expect(initial).toHaveLength(7);
+        expect(initial.every((c) => c.active === false)).toBe(true);
+    });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest tests/securityPanelState.test.js`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement `src/securityPanelState.js`**
+
+Key points: `Map<network, Object<condition, boolean>>`; conditions default `false`; `applyReading` returns `[]` when the value is unchanged; `system_arm` mode 0 clears `panic`, `arm_failed`, `fire`; non-zero mode clears only `arm_failed`; `seedFromStatusReport` applies `tamperActive`/`panicActive`; `initialStates` lazily creates the network entry and returns all seven current values.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `npx jest tests/securityPanelState.test.js`
+Expected: PASS.
+
+- [ ] **Step 5: Full gates and commit**
+
+```bash
+npm test && npm run lint && npm run typecheck
+git add src/securityPanelState.js tests/securityPanelState.test.js
+git commit -m "feat: track C-Bus security panel trouble state per network (#42)"
+```
+
+---
+
+### Task 4: Publish trouble sensors and log them
+
+**Files:**
+- Modify: `src/haDiscoveryPublishers.js` (add `ensureSecurityPanelDiscovery` + `_createSecurityPanelDiscovery` after `_createSecurityZoneDiscovery` ~line 667; add `_securityPanelSeen` field near `_securityZoneSeen` ~line 100)
+- Modify: `src/securityEventHandler.js` (wire `SecurityPanelState`, handle `kind: 'panel_trouble'`, extend `_describeSystemEvent`, publish panel topics)
+- Modify: `src/eventPublisher.js` (accept `kind: 'security_panel'` readings, near the `security_zone` branch ~line 425)
+- Test: `tests/securityDiscovery.test.js`, `tests/securityEventHandler.test.js`
+
+**Interfaces:**
+- Consumes: `SecurityPanelState` (Task 3), `PANEL_TROUBLE_CONDITIONS` (Task 2), `_emitEventLog(..., description)` (Task 1).
+- Produces: `ensureSecurityPanelDiscovery(network, appId) -> boolean`; retained state on `cbus/read/{net}/{app}/panel/{condition}/state` as `ON`/`OFF`.
+
+- [ ] **Step 1: Write the failing discovery tests**
+
+```js
+describe('security panel trouble discovery', () => {
+    it('publishes seven diagnostic binary_sensors on one shared panel device', () => {
+        haDiscovery.ensureSecurityPanelDiscovery('254', '208');
+        const configs = publishedConfigsMatching('/panel_');
+        expect(configs).toHaveLength(7);
+        for (const payload of configs) {
+            expect(payload.entity_category).toBe('diagnostic');
+            expect(payload.device.identifiers).toEqual(['cgateweb_254_208_panel']);
+            expect(payload.device.model).toBe('C-Bus Security Panel');
+        }
+    });
+
+    it('assigns the agreed device classes', () => {
+        haDiscovery.ensureSecurityPanelDiscovery('254', '208');
+        expect(deviceClassFor('mains')).toBe('problem');
+        expect(deviceClassFor('battery')).toBe('battery');
+        expect(deviceClassFor('tamper')).toBe('tamper');
+        expect(deviceClassFor('panic')).toBe('safety');
+        expect(deviceClassFor('line')).toBe('problem');
+        expect(deviceClassFor('arm_failed')).toBe('problem');
+        expect(deviceClassFor('fire')).toBe('smoke');
+    });
+
+    it('is idempotent', () => {
+        expect(haDiscovery.ensureSecurityPanelDiscovery('254', '208')).toBe(true);
+        expect(haDiscovery.ensureSecurityPanelDiscovery('254', '208')).toBe(false);
+    });
+
+    it('retracts and skips an excluded panel', () => {
+        haDiscovery.exclude.add('254/208/panel');
+        expect(haDiscovery.ensureSecurityPanelDiscovery('254', '208')).toBe(false);
+        expect(retractedTopics()).toHaveLength(7);
+    });
+
+    it('publishes nothing when ha_discovery_enabled is false', () => {
+        settings.ha_discovery_enabled = false;
+        expect(haDiscovery.ensureSecurityPanelDiscovery('254', '208')).toBe(false);
+    });
+});
+```
+
+And in `tests/securityEventHandler.test.js`:
+
+```js
+it('publishes ON for a mains failure and OFF when restored', () => {
+    const handler = createHandler();
+    handler.handleLine('# security mains_failure //PROJ/254/208 #sourceunit=18 OID=');
+    expect(eventPublisher.publishReading).toHaveBeenCalledWith('254', '208', 'panel/mains',
+        { kind: 'security_panel', active: true });
+    handler.handleLine('# security mains_restored //PROJ/254/208 #sourceunit=18 OID=');
+    expect(eventPublisher.publishReading).toHaveBeenLastCalledWith('254', '208', 'panel/mains',
+        { kind: 'security_panel', active: false });
+});
+
+it('logs panel trouble at INFO', () => {
+    const handler = createHandler();
+    handler.handleLine('# security mains_failure //PROJ/254/208 #sourceunit=18 OID=');
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('Mains power failure'));
+});
+
+it('clears panic on disarm without a panic_off verb', () => {
+    const handler = createHandler();
+    handler.handleLine('# security panic_activated //PROJ/254/208 #sourceunit=18 OID=');
+    handler.handleLine('# security system_arm //PROJ/254/208 0 #sourceunit=18 OID=');
+    expect(eventPublisher.publishReading).toHaveBeenCalledWith('254', '208', 'panel/panic',
+        { kind: 'security_panel', active: false });
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest tests/securityDiscovery.test.js tests/securityEventHandler.test.js`
+Expected: FAIL — `ensureSecurityPanelDiscovery` is not a function.
+
+- [ ] **Step 3: Implement discovery**
+
+`_createSecurityPanelDiscovery(networkId, appId)` loops the seven conditions, building for each:
+
+```js
+const uniqueId = `cgateweb_${networkId}_${appId}_panel_${condition}`;
+const readBase = `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/panel/${condition}`;
+const payload = {
+    name: PANEL_CONDITION_LABELS[condition],   // 'Mains power', 'Battery', 'Tamper', 'Panic', 'Phone line', 'Arm failed', 'Fire alarm'
+    unique_id: uniqueId,
+    state_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_STATE}`,
+    payload_on: MQTT_STATE_ON,
+    payload_off: MQTT_STATE_OFF,
+    device_class: PANEL_CONDITION_DEVICE_CLASSES[condition],
+    entity_category: 'diagnostic',
+    qos: 0,
+    device: buildDeviceBlock({
+        identifiers: [`cgateweb_${networkId}_${appId}_panel`],
+        name: `C-Bus Security Panel ${networkId}/${appId}`,
+        model: 'C-Bus Security Panel'
+    }),
+    origin: buildOriginBlock()
+};
+```
+
+`name` is a real string here, not `null` as zones use — these are seven entities on a shared device, so each needs its own name. Register every topic in `_publishedTopics` and `_eventDrivenDiscoveryTopics`; on exclusion, retract all seven. Exclusion key is `{net}/{app}/panel`.
+
+- [ ] **Step 4: Implement publishing and logging**
+
+In `src/eventPublisher.js`, next to the `security_zone` branch:
+
+```js
+} else if (reading.kind === 'security_panel') {
+    this._publishState(network, application, group, reading.active ? MQTT_STATE_ON : MQTT_STATE_OFF);
+}
+```
+
+(Match the exact helper the `security_zone` branch uses; `group` is already the `panel/{condition}` path segment.)
+
+In `src/securityEventHandler.js`: construct `this.panelState = new SecurityPanelState()`; add a `panel_trouble` branch that calls `applyReading`, publishes each changed condition, logs at INFO via `_describeSystemEvent`, and emits an event-log entry with the description. Feed `system_arm` readings through `applyReading` as well (for the derived clears) *in addition to* their existing handling. Seed at discovery time from `initialStates`, and call `seedFromStatusReport` in the status-report branch.
+
+Extend `_describeSystemEvent` with the seven conditions in both senses: `Mains power failure` / `Mains power restored`, `Battery low` / `Battery restored`, `Tamper detected` / `Tamper cleared`, `Panic activated` / `Panic cleared`, `Phone line cut` / `Phone line restored`, `Arm failed` / `Arm failure cleared`, `Fire alarm` / `Fire alarm cleared`.
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `npx jest tests/securityDiscovery.test.js tests/securityEventHandler.test.js`
+Expected: PASS.
+
+- [ ] **Step 6: Full gates and commit**
+
+```bash
+npm test && npm run lint && npm run typecheck
+git add src/haDiscoveryPublishers.js src/securityEventHandler.js src/eventPublisher.js tests/
+git commit -m "feat: security panel trouble sensors as diagnostic binary_sensors (#42)"
+```
+
+---
+
+### Task 5: Discovery config payload cache and republish
+
+**Files:**
+- Modify: `src/haDiscovery.js` (add `_publishedConfigPayloads` next to `_publishedTopics` ~line 50; add `republishDiscoveryConfigs()`)
+- Modify: `src/haDiscoveryPublishers.js` (record payloads wherever `_publishedTopics.add` runs; delete on retraction)
+- Test: `tests/haDiscovery.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `haDiscovery.republishDiscoveryConfigs() -> number` (count republished).
+
+- [ ] **Step 1: Write the failing test**
+
+```js
+it('replays every published discovery config payload', () => {
+    haDiscovery.ensureSecurityZoneDiscovery('254', '208', '13');
+    mqttManager.publish.mockClear();
+    const count = haDiscovery.republishDiscoveryConfigs();
+    expect(count).toBe(1);
+    expect(mqttManager.publish).toHaveBeenCalledWith(
+        expect.stringContaining('/config'), expect.stringContaining('cgateweb_254_208_13'),
+        expect.objectContaining({ retain: true })
+    );
+});
+
+it('does not replay a retracted config', () => {
+    haDiscovery.ensureSecurityZoneDiscovery('254', '208', '13');
+    haDiscovery.exclude.add('254/208/14');
+    haDiscovery.ensureSecurityZoneDiscovery('254', '208', '14');
+    expect(haDiscovery.republishDiscoveryConfigs()).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest tests/haDiscovery.test.js -t republish`
+Expected: FAIL — not a function.
+
+- [ ] **Step 3: Implement**
+
+Add `this._publishedConfigPayloads = new Map();` beside `_publishedTopics`. Introduce one helper used by every config publish site so the two collections cannot drift:
+
+```js
+_recordDiscoveryConfig(topic, payload) {
+    this._publishedTopics.add(topic);
+    this._publishedConfigPayloads.set(topic, payload);
+}
+
+_forgetDiscoveryConfig(topic) {
+    this._publishedTopics.delete(topic);
+    this._publishedConfigPayloads.delete(topic);
+}
+
+republishDiscoveryConfigs() {
+    let count = 0;
+    for (const [topic, payload] of this._publishedConfigPayloads) {
+        this._publish(topic, payload, MQTT_RETAINED_STATE_OPTIONS);
+        count++;
+    }
+    if (count > 0) this.logger.info(`Republished ${count} HA Discovery config(s)`);
+    return count;
+}
+```
+
+Replace the existing `_publishedTopics.add(...)` / `.delete(...)` calls in `haDiscovery.js` and `haDiscoveryPublishers.js` with these helpers. Keep `_eventDrivenDiscoveryTopics` handling exactly as it is.
+
+- [ ] **Step 4: Run to verify pass, then full gates and commit**
+
+```bash
+npx jest tests/haDiscovery.test.js tests/securityDiscovery.test.js tests/haDiscoveryTree.test.js
+npm test && npm run lint && npm run typecheck
+git add src/haDiscovery.js src/haDiscoveryPublishers.js tests/haDiscovery.test.js
+git commit -m "refactor: cache HA Discovery config payloads for replay"
+```
+
+---
+
+### Task 6: State resync on HA restart and broker reconnect
+
+**Files:**
+- Create: `src/stateResyncCoordinator.js`
+- Modify: `src/defaultSettings.js` (four new settings)
+- Modify: `src/mqttManager.js` (`_handleConnect` ~line 290-320: emit `reconnect`, subscribe to the birth topic)
+- Modify: `src/cgateWebBridge.js` (~line 407: intercept the birth topic before routing to `mqttCommandRouter`; construct and wire the coordinator)
+- Test: `tests/stateResyncCoordinator.test.js` (new), `tests/mqttManager.test.js`
+
+**Interfaces:**
+- Consumes: `haDiscovery.republishDiscoveryConfigs()` (Task 5), `securityEventHandler.requestStatusSync(network, trigger)`, `bridgeInitializationService._resolveGetallNetApps()`.
+- Produces: `StateResyncCoordinator` with `requestResync(trigger, {republishDiscovery = false} = {})` and `dispose()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+describe('StateResyncCoordinator', () => {
+    it('queues a getall per configured net/app', () => {
+        coordinator.requestResync('ha-birth');
+        jest.advanceTimersByTime(5000);
+        expect(commandQueue.add).toHaveBeenCalledWith('GET //TEST/254/56/* level\n');
+    });
+
+    it('collapses two triggers inside the debounce window into one resync', () => {
+        coordinator.requestResync('ha-birth');
+        coordinator.requestResync('mqtt-reconnect');
+        jest.advanceTimersByTime(5000);
+        expect(commandQueue.add).toHaveBeenCalledTimes(1);
+    });
+
+    it('republishes discovery configs only when asked', () => {
+        coordinator.requestResync('ha-birth');
+        jest.advanceTimersByTime(5000);
+        expect(haDiscovery.republishDiscoveryConfigs).not.toHaveBeenCalled();
+        coordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+        jest.advanceTimersByTime(5000);
+        expect(haDiscovery.republishDiscoveryConfigs).toHaveBeenCalledTimes(1);
+    });
+
+    it('requests a security status sync, which getall cannot cover', () => {
+        coordinator.requestResync('ha-birth');
+        jest.advanceTimersByTime(5000);
+        expect(securityEventHandler.requestStatusSync).toHaveBeenCalledWith('254', 'resync');
+    });
+
+    it('logs at debug and sends nothing when no networks are configured', () => {
+        initializationService._resolveGetallNetApps.mockReturnValue([]);
+        coordinator.requestResync('ha-birth');
+        jest.advanceTimersByTime(5000);
+        expect(commandQueue.add).not.toHaveBeenCalled();
+        expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('no getall'));
+    });
+
+    it('honours the disable flags', () => {
+        settings.stateResyncOnHaRestart = false;
+        coordinator.requestResync('ha-birth');
+        jest.advanceTimersByTime(5000);
+        expect(commandQueue.add).not.toHaveBeenCalled();
+    });
+});
+```
+
+And in `tests/mqttManager.test.js`:
+
+```js
+it('emits reconnect only after a prior successful connect', () => {
+    const onReconnect = jest.fn();
+    manager.on('reconnect', onReconnect);
+    manager._handleConnect();
+    expect(onReconnect).not.toHaveBeenCalled();
+    manager._handleConnect();
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+});
+
+it('subscribes to the HA birth topic on connect', () => {
+    manager._handleConnect();
+    expect(mockClient.subscribe).toHaveBeenCalledWith('homeassistant/status', expect.any(Function));
+});
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx jest tests/stateResyncCoordinator.test.js tests/mqttManager.test.js`
+Expected: FAIL — module not found; `reconnect` never emitted.
+
+- [ ] **Step 3: Add the settings**
+
+In `src/defaultSettings.js`:
+
+```js
+// State resync after a Home Assistant or MQTT broker restart (issue #44).
+// HA keeps running the add-on across its own restart, so nothing would
+// otherwise republish state and entities sit unknown until the next C-Bus
+// event. Both default on: this is a fix, not an opt-in feature.
+stateResyncOnHaRestart: true,
+stateResyncOnMqttReconnect: true,
+stateResyncDebounceMs: 5000,
+// Falls back to `${ha_discovery_prefix}/status` when null.
+haStatusTopic: null,
+```
+
+- [ ] **Step 4: Implement the coordinator**
+
+`requestResync(trigger, opts)` returns early when the matching disable flag is set, records `republishDiscovery` as sticky-OR across collapsed triggers, and (re)arms a single `setTimeout` for `stateResyncDebounceMs`. On fire: republish configs if requested; for each `_resolveGetallNetApps()` entry queue `GET //${cbusname}/${netapp}/* level\n`; for each distinct network call `securityEventHandler.requestStatusSync(network, 'resync')`; log one INFO summary naming the trigger and counts, or DEBUG when there is nothing to do. `dispose()` clears the pending timer.
+
+`requestStatusSync` currently dedupes per session on the `early`/`postSync` slots (`securityEventHandler.js:103-133`), so add a `'resync'` trigger that bypasses the dedupe — otherwise the second and later resyncs would silently do nothing. Add a test asserting a second resync still sends.
+
+- [ ] **Step 5: Wire the triggers**
+
+`src/mqttManager.js` `_handleConnect`: capture `const isReconnect = this._hasConnectedOnce;` before the flag is set, subscribe to `this._haStatusTopic()` alongside `cbus/write/#`, and `this.emit('reconnect')` after `this.emit('connect')` when `isReconnect`.
+
+`src/cgateWebBridge.js` (~line 407):
+
+```js
+this.mqttManager.on('message', (topic, payload) => {
+    if (topic === this.mqttManager.haStatusTopic) {
+        if (String(payload).trim().toLowerCase() === 'online') {
+            this.stateResyncCoordinator.requestResync('ha-birth');
+        }
+        return;
+    }
+    this.mqttCommandRouter.routeMessage(topic, payload);
+});
+this.mqttManager.on('reconnect', () => {
+    this.stateResyncCoordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+});
+```
+
+- [ ] **Step 6: Run to verify pass, then full gates and commit**
+
+```bash
+npx jest tests/stateResyncCoordinator.test.js tests/mqttManager.test.js tests/cgateWebBridge.test.js
+npm test && npm run lint && npm run typecheck
+git add src/stateResyncCoordinator.js src/defaultSettings.js src/mqttManager.js src/cgateWebBridge.js tests/
+git commit -m "fix: resync entity state after Home Assistant or broker restart (#44)"
+```
+
+---
+
+### Task 7: Release v1.21.0
+
+**Files:**
+- Modify: `package.json`, `homeassistant-addon/config.yaml`, `CHANGELOG.md`
+
+- [ ] **Step 1: Bump both versions to 1.21.0**
+
+Both files must agree or CI's `version-sync` job fails.
+
+- [ ] **Step 2: Write the CHANGELOG entry**
+
+Cover: Live Events descriptions for security rows; seven panel-trouble diagnostic sensors on a shared panel device; state resync after HA or broker restart. Plain language, no emdashes in issue-facing copy.
+
+- [ ] **Step 3: Full gates plus the add-on validators**
+
+```bash
+npm test && npm run lint && npm run typecheck
+npm run validate:translations && npm run validate:addon-config
+```
+
+- [ ] **Step 4: Commit, push, tag**
+
+```bash
+git add package.json homeassistant-addon/config.yaml CHANGELOG.md
+git commit -m "chore: release v1.21.0"
+git push origin master
+git tag v1.21.0 && git push origin v1.21.0
+```
+
+- [ ] **Step 5: Watch CI, then backfill the GitHub Release**
+
+```bash
+gh run watch
+gh release create v1.21.0 --notes "<CHANGELOG section>"
+```
+
+- [ ] **Step 6: Reply on #42 and #44**
+
+Plain text, concise, no emdashes. On #42, list what shipped and ask @djagerif to confirm the three inferred verbs (`low_battery`, `tamper_on`, a panic clear) if they can produce a low battery or tamper. On #44, describe both triggers and note that `GETSTATE ... levels` was deferred in favour of the existing getall path.
+
+---
+
+## Self-Review
+
+**Spec coverage:** Live Events enrichment → Task 1. Verb decoding incl. inferred verbs and detail suffixes → Task 2. Panel state, dedupe, derived clears, status-report seeding → Task 3. Discovery (shared device, diagnostic category, device classes, exclusion), topics, initial seeding, INFO logging, no new config option → Task 4. Discovery payload cache → Task 5. Coordinator, both triggers, debounce, security status sync, empty-network case, four new settings → Task 6. Release and issue replies → Task 7. "Not doing" (`GETSTATE`) is recorded in Task 7 step 6.
+
+**Two spec gaps found and fixed while planning:**
+1. `requestStatusSync` dedupes per session, so the coordinator's security sync would fire once and never again. Task 6 step 4 adds a `'resync'` trigger that bypasses the dedupe, with a test.
+2. `arm_failed` and `fire_alarm` already return their own `kind`s, so folding them into `panel_trouble` is a behaviour change to existing decoder output. Task 2 step 4 calls out updating the existing assertions.
+
+**Type consistency:** `condition` keys are identical across Tasks 2, 3 and 4 (`mains`, `battery`, `tamper`, `panic`, `line`, `arm_failed`, `fire`). `applyReading`/`seedFromStatusReport`/`initialStates` all return `Array<{condition, active}>`. `_emitEventLog`'s new trailing `description` param is used consistently in Tasks 1 and 4.

--- a/docs/superpowers/specs/2026-07-31-security-trouble-sensors-and-restart-resync-design.md
+++ b/docs/superpowers/specs/2026-07-31-security-trouble-sensors-and-restart-resync-design.md
@@ -1,0 +1,331 @@
+# Security panel trouble sensors, Live Events enrichment, and restart state resync
+
+Date: 2026-07-31
+Issues: [#42](https://github.com/dougrathbone/cgateweb/issues/42) (security application, phase 1 follow-up), [#44](https://github.com/dougrathbone/cgateweb/issues/44) (level sync after HA or MQTT restart)
+Target release: v1.21.0
+
+## Background
+
+Phase 1 of the security application shipped across v1.20.0 to v1.20.2 and the alpha tester
+(@djagerif, running a 64-zone Cytech Comfort II panel on network 254, app 208) confirmed zone
+binary_sensors, the log-level split and label renames all work. Two items from their last two
+comments on #42 remain, and #44 arrived on 2026-07-31 as a separate report.
+
+Three pieces of work, ordered smallest-risk first:
+
+1. **Live Events enrichment** — security rows in the web UI render as raw levels.
+2. **Panel trouble sensors** — seven captured panel-wide verbs are decoded nowhere and
+   surface only as `Security line not decoded (verb pending support)` at DEBUG.
+3. **Restart state resync** — HA or broker restarts leave entities with no state.
+
+## 1. Live Events enrichment (#42)
+
+### Problem
+
+`SecurityEventHandler._emitEventLog` (`src/securityEventHandler.js:308`) emits the
+lighting-shaped SSE entry `{ts, network, app, group, level, type, label?}`. The UI therefore
+renders an arm sequence as level percentages:
+
+```
+12:21:11   254/208/13   Group 13   0 (0%)
+12:21:29   254/208/0    —          255 (100%)
+```
+
+`_describeSystemEvent` (`securityEventHandler.js:235`) already builds the correct sentence for
+the INFO log; it is simply never sent to the UI.
+
+### Design
+
+Add an optional `description` field to the SSE entry. Populate it for all three security event
+shapes:
+
+| Event shape | description |
+| --- | --- |
+| zone | `Zone sealed` / `Zone unsealed` / `Zone open` / `Zone short` |
+| system verb | `_describeSystemEvent` output, e.g. `System armed (Day mode)` |
+| panel trouble | `Mains power failure`, `Battery low`, … (see section 2) |
+
+In `public/index.html`:
+
+- the entry normaliser (~line 2001) carries `description` through alongside `label`;
+- `renderEventLog()` (~line 1934) renders `description` in the value column **instead of**
+  `N (P%)` when present, and suppresses the level bar for that row;
+- the filter input matches `description` in addition to address and label.
+
+Lighting rows are untouched — they have no `description` and keep their level text and bar.
+
+Target rendering:
+
+```
+12:21:11   254/208/13   Group 13   Zone unsealed
+12:21:15   254/208/13   Group 13   Zone bypassed
+12:21:29   254/208      —          Ready to arm
+12:21:45   254/208      —          System armed (Day mode)
+12:23:53   254/208      —          System disarmed
+```
+
+## 2. Panel trouble sensors (#42)
+
+### Captured verbs
+
+From @djagerif's panic, mains-failure and disarm captures, none of which reach the dispatch
+chain in `src/applicationDecoders/securityDecoder.js` (falls through to `return null` at line
+261):
+
+```
+# security panic_activated //MIDSTRM/254/208
+# security mains_failure //MIDSTRM/254/208
+# security mains_restored //MIDSTRM/254/208
+# security low_battery_corrected //MIDSTRM/254/208
+# security line_cut_alarm //MIDSTRM/254/208 line_cut_alarm_cleared
+# security tamper_off //MIDSTRM/254/208
+```
+
+`arm_failed` and `fire_alarm` are already decoded (`securityDecoder.js:248`) but published
+nowhere.
+
+### Condition map
+
+Seven conditions. The `<verb>_raised` / `<verb>_cleared` detail-suffix convention already used
+by `arm_failed` generalises to `line_cut_alarm` and `fire_alarm`.
+
+| Condition | device_class | ON | OFF |
+| --- | --- | --- | --- |
+| `mains` | `problem` | `mains_failure` | `mains_restored` |
+| `battery` | `battery` | `low_battery` | `low_battery_corrected` |
+| `tamper` | `tamper` | `tamper_on` | `tamper_off` |
+| `panic` | `safety` | `panic_activated` | `panic_off`, `panic_cleared`, or disarm |
+| `line` | `problem` | `line_cut_alarm` (`_raised`) | `line_cut_alarm_cleared` |
+| `arm_failed` | `problem` | `arm_failed` (`_raised`) | `arm_failed_cleared`, or a successful arm |
+| `fire` | `smoke` | `fire_alarm` (`_raised`) | `fire_alarm_cleared`, or disarm |
+
+**Inferred verb names.** The captures contain only one half of three pairs: `low_battery_corrected`
+without a raise, `tamper_off` without a raise, and `panic_activated` without a clear. `low_battery`,
+`tamper_on` and `panic_off` / `panic_cleared` are therefore inferred from the naming convention of
+the confirmed pairs. All three are handled defensively — an inferred verb that never arrives costs
+nothing, and the derived clears below mean `panic` still recovers without `panic_off` existing. Ask
+the tester to confirm the raise verbs if they can produce a mains-independent low battery or a
+tamper.
+
+**Derived clears.** The panel never explicitly clears `panic`, `arm_failed` or `fire` in the
+captures, so those three clear on `system_arm` with mode 0. This follows the tester's note that
+"disarm clears all possible trouble conditions" and is corroborated by both captured sequences:
+`arm_failed_raised` → `alarm_on` → `alarm_off` → `system_arm 0`, and `fire_alarm_raised` →
+`alarm_on` → `alarm_off` → `system_arm 0`. `arm_failed` additionally clears on a successful arm
+(`system_arm` with a non-zero mode).
+
+### Components
+
+**`src/applicationDecoders/securityDecoder.js`** stays a pure translator holding no state. New
+verbs return `{kind: 'panel_trouble', network, application, condition, active, verb, detail}`.
+An unrecognised verb still returns `null` so it falls through to raw event capture.
+
+**`src/securityPanelState.js`** (new, ~80 lines). Owns the verb-to-condition map, the current
+state per network, and dedupe — a repeated `mains_failure` publishes nothing. Kept out of
+`securityEventHandler.js` because that file is already 314 lines and a standalone unit is
+testable without mocking the whole handler.
+
+Interface:
+
+- `applyReading(reading) -> [{condition, active, changed}]` — also handles derived clears, so a
+  `system_arm` mode 0 reading can return several cleared conditions at once.
+- `seedFromStatusReport(reading) -> [{condition, active, changed}]`
+- `getState(network) -> {condition: boolean}`
+
+**`src/haDiscoveryPublishers.js`** gains `ensureSecurityPanelDiscovery(network, appId)`,
+mirroring `ensureSecurityZoneDiscovery`'s contract (`haDiscoveryPublishers.js:590`): idempotent
+Seen set, `exclude` honoured with retraction of the retained config, topics registered in both
+`_publishedTopics` and `_eventDrivenDiscoveryTopics` so tree-run stale cleanup skips them.
+Triggered by the first security traffic for that network, as zones are.
+
+All seven entities share one device block:
+
+```js
+device: {
+  identifiers: ['cgateweb_254_208_panel'],
+  name: 'C-Bus Security Panel 254/208',
+  model: 'C-Bus Security Panel'
+}
+entity_category: 'diagnostic'
+```
+
+`entity_category: 'diagnostic'` groups them under Diagnostics on the device page rather than
+cluttering dashboards. The 64 zone devices are unchanged.
+
+### Topics
+
+```
+cbus/read/254/208/panel/mains/state       -> ON | OFF
+cbus/read/254/208/panel/battery/state     -> ON | OFF
+cbus/read/254/208/panel/tamper/state      -> ON | OFF
+cbus/read/254/208/panel/panic/state       -> ON | OFF
+cbus/read/254/208/panel/line/state        -> ON | OFF
+cbus/read/254/208/panel/arm_failed/state  -> ON | OFF
+cbus/read/254/208/panel/fire/state        -> ON | OFF
+```
+
+unique_id: `cgateweb_254_208_panel_<condition>`.
+
+A non-numeric `panel` segment cannot be confused with a zone number. Read topics are
+publish-only from cgateweb and nothing in the bridge parses them numerically; HA takes the exact
+topic from the discovery config.
+
+### Initial state
+
+The panel emits trouble verbs only on transition and there is no query for mains, battery, line,
+arm-fail or fire state. `status_report_1` does carry authoritative tamper and panic bytes, which
+the decoder already unpacks (`securityDecoder.js:140`).
+
+At discovery time, seed all seven:
+
+- `tamper`, `panic` — from the `status_report_1` bytes when a report has already been seen for
+  that network.
+- `mains`, `battery`, `line`, `arm_failed`, `fire` — `OFF` (assumed healthy).
+- `tamper`, `panic` when no `status_report_1` has arrived yet — `OFF`, then corrected by
+  `seedFromStatusReport` when the first report lands. Discovery is triggered by the first
+  security traffic for a network, which may precede the status reports the bridge requests, so
+  this ordering must not be assumed either way.
+
+**Accepted risk:** a trouble condition raised before cgateweb started reads OK until the next
+transition or a disarm re-emits its cleared verb. The alternative leaves entities `Unknown`
+indefinitely on a healthy panel, which is the complaint behind #44.
+
+### Logging
+
+New verbs join `_describeSystemEvent` and log at INFO, preserving the level split the tester
+asked for (panel events INFO, routine zone changes DEBUG): `Mains power failure`, `Mains power
+restored`, `Battery low`, `Battery restored`, `Tamper detected`, `Tamper cleared`, `Phone line
+cut`, `Phone line restored`, `Panic activated`, `Fire alarm`.
+
+### Configuration
+
+**No new config option.** Publishing is gated on the existing security app id setting plus
+`ha_discovery_enabled`. `homeassistant-addon/config.yaml` and the 17 translation files are
+untouched, so `validate:translations` and `validate:addon-config` cannot drift.
+
+## 3. Restart state resync (#44)
+
+### Problem
+
+`retainreads` defaults to `false` (`src/defaultSettings.js:14`) and `getallonstart` only fires at
+bridge startup. Nothing subscribes to the HA birth topic. Two failure modes:
+
+- **HA restarts.** The add-on keeps running, so it publishes nothing. HA has no retained state to
+  read and entities sit unknown until the next physical C-Bus event — the reporter's "two
+  lightning icons" that snap to a real icon on first use.
+- **The broker restarts.** Without retained-message persistence the entities disappear entirely,
+  because the retained discovery configs are gone too.
+
+### Components
+
+**`src/stateResyncCoordinator.js`** (new, ~90 lines).
+
+- `requestResync(trigger, {republishDiscovery})`, debounced by `stateResyncDebounceMs`, reusing
+  the dedupe shape shipped for security sync in v1.20.1. A broker bounce that also restarts HA
+  resyncs once, not twice.
+- On fire: republish discovery configs if asked, then queue
+  `GET //PROJ/{netapp}/* level` for each entry from `_resolveGetallNetApps()`, then request a
+  security status sync per network. One INFO summary line naming the trigger and the count.
+
+**Two consequences of reusing the getall path**, both handled explicitly:
+
+- The security application is deliberately excluded from getall
+  (`bridgeInitializationService.js:127` — panels do not answer lighting-style getall, spec
+  §5.9). The coordinator therefore also calls
+  `securityEventHandler.requestStatusSync(network, 'resync')`. Without this, zone sensors would
+  stay stale across an HA restart, reintroducing #44 inside the feature just shipped for #42.
+- An install with no getall or discovery networks configured has nothing to resync. That logs at
+  DEBUG rather than silently doing nothing.
+
+**Triggers.**
+
+- *MQTT reconnect.* `mqttManager` already tracks `_hasConnectedOnce`
+  (`src/mqttManager.js:62`). `_handleConnect` emits a distinct `reconnect` event when that flag
+  was already true, so a first connect is unchanged and startup's own getall still covers it.
+  Wired to `requestResync('mqtt-reconnect', {republishDiscovery: true})`.
+- *HA birth message.* `mqttManager` subscribes to the birth topic next to `cbus/write/#`
+  (`src/mqttManager.js:311`). Payload `online` triggers `requestResync('ha-birth')`; `offline`
+  (HA's shutdown message) is ignored. The topic defaults to `${ha_discovery_prefix}/status`,
+  which is `homeassistant/status` for the default prefix and follows the prefix when a user has
+  changed it, overridable via `haStatusTopic`.
+
+**Discovery payload cache.** `haDiscovery._publishedTopics` (`src/haDiscovery.js:50`) is a Set of
+topics with no payloads, so republishing needs a parallel `Map<topic, payload>` written wherever
+`_publishedTopics.add` happens and deleted on retraction, plus `republishDiscoveryConfigs()` to
+replay it retained. Bounded by entity count: a few hundred payloads of roughly 500 bytes. The
+alternative — re-running the TREEXML sweep — would drag in the retry, epoch and resync machinery
+(`haDiscovery.js:58`-`80`) for no benefit.
+
+### Settings
+
+New in `src/defaultSettings.js`, all additive:
+
+| Setting | Default | Purpose |
+| --- | --- | --- |
+| `stateResyncOnHaRestart` | `true` | Resync on HA birth message |
+| `stateResyncOnMqttReconnect` | `true` | Resync after a mid-session broker reconnect |
+| `stateResyncDebounceMs` | `5000` | Collapse near-simultaneous triggers |
+| `haStatusTopic` | `null` | Override; falls back to `${ha_discovery_prefix}/status` |
+
+Not exposed in `config.yaml`, so no translation churn; standalone users override in
+`settings.js`. The two booleans default on because that is the fix — the only behaviour change is
+the intended one.
+
+### Not doing
+
+The reporter suggested `GETSTATE //PROJECT/{net} levels`, which covers all applications on a
+network in one command. Rejected for now: its reply lines carry an OID token where `-` appears in
+the form the parser handles today, so it needs new parsing for no functional gain over the
+existing, already-exercised getall path. Worth revisiting only if per-app getall proves too slow
+on large projects.
+
+## Error handling
+
+- A decoded reading for a different application id is ignored, as today
+  (`securityEventHandler.js:142`).
+- Undecodable security lines keep falling through to raw event capture rather than being
+  consumed, preserving the existing diagnostic path for verbs still unknown.
+- `republishDiscoveryConfigs()` publishes through `mqttManager`, which already queues retained
+  publishes when disconnected and replays them on reconnect
+  (`src/mqttManager.js:65`-`70`), so a resync racing a flapping broker cannot lose configs.
+- A resync with an empty net/app list logs at DEBUG and does nothing.
+- HA flapping is bounded by the debounce; `offline` payloads never trigger work.
+
+## Testing
+
+Extend:
+
+- `tests/applicationDecoders/securityDecoder.test.js` — seven new verbs, `_raised`/`_cleared`
+  detail suffixes, unknown verbs still return `null`.
+- `tests/securityDiscovery.test.js` — seven configs, shared device block, `entity_category`,
+  exclusion with retraction.
+- `tests/securityEventHandler.test.js` — INFO text per verb, `description` present on zone,
+  system and panel SSE entries.
+- `tests/mqttManager.test.js` — `reconnect` fires only after a prior connect, birth topic
+  subscribed, birth payload routing.
+
+New:
+
+- `tests/securityPanelState.test.js` — transitions, dedupe of repeated raises, derived clears on
+  disarm and on successful arm, seeding from `status_report_1`.
+- `tests/stateResyncCoordinator.test.js` — debounce collapses two triggers into one, `online` vs
+  `offline`, reconnect vs first connect, empty net/app list, security status sync included,
+  discovery republish only on the reconnect path.
+
+No DOM test harness exists for `public/index.html` (`tests/webServer.test.js` only asserts it is
+served), so the render change is covered by the SSE payload assertions plus a manual check
+against the running add-on.
+
+## Delivery
+
+Three commits, smallest risk first, per the repo's batch process:
+
+1. Live Events enrichment for security rows (#42).
+2. Panel trouble binary_sensors (#42).
+3. HA and broker restart state resync (#44).
+
+Then `chore: release v1.21.0` with the CHANGELOG entry, version bumped in both `package.json`
+and `homeassistant-addon/config.yaml`, tag `v1.21.0` pushed to trigger HACS distribution, and a
+backfilled GitHub Release on the source repo.
+
+`npm test`, `npm run lint` and `npm run typecheck` must pass before each commit.

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.21.0] - 2026-07-31
+
+### Added
+
+- **Security Alpha: panel health now appears in Home Assistant** (#42). Seven new `binary_sensor` entities track the panel itself rather than its zones: mains power, battery, tamper, panic, phone line, arm failure and fire alarm. They share a single "C-Bus Security Panel" device and are marked as diagnostics, so they group under Diagnostics on the device page instead of landing on your dashboards. Verbs your panel was already sending (`mains_failure`, `mains_restored`, `low_battery_corrected`, `tamper_off`, `panic_activated`, `line_cut_alarm`, plus `arm_failed` and `fire_alarm`) were previously discarded as "verb pending support"; they now drive real entities and log at INFO in plain language. Note that the panel only reports changes and offers no way to query mains, battery, line, arm-fail or fire state, so those four start as OK and correct themselves on the next change or disarm; tamper and panic are seeded from the panel's status report, which does carry them. Three verbs are inferred rather than captured (`low_battery`, `tamper_on`, and a panic clear) because the test panel only ever emitted the other half of those pairs, so please report on #42 if your panel names them differently.
+
+### Fixed
+
+- **Entity state is restored after Home Assistant or your MQTT broker restarts** (#44). Restarting Home Assistant does not restart the add-on, so nothing used to republish state: HA came back with entities in an unknown state until the next time something physically changed on the C-Bus, which is why a relay light would show two lightning-bolt icons and only turn into a proper switch icon once you used it. Restarting the broker was worse, since without retained-message persistence the entities disappeared entirely. The add-on now watches for Home Assistant's online message and for its own broker reconnection, re-requests levels for your configured networks, re-requests security zone state (security panels ignore the normal level request), and on a broker reconnect republishes the discovery configuration so the entities come back. Near-simultaneous restarts are collapsed into a single refresh.
+- **Security Alpha: the Live Events window now describes security events instead of showing meaningless levels** (#42). An arm sequence used to render as a column of `0 (0%)` and `255 (100%)` rows; it now reads "Zone unsealed", "Zone 13 bypassed", "Ready to arm", "Exit delay started", "System armed (Day mode)" and "System disarmed". Panel-wide events also stop showing a bogus `/0` group on the end of their address. Lighting events are unchanged, and the filter box searches the new text.
+
 ## [1.20.2] - 2026-07-28
 
 ### Fixed

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.20.2"
+version: "1.21.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.19.0",
+  "version": "1.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.19.0",
+      "version": "1.21.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.20.2",
+  "version": "1.21.0",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",

--- a/public/index.html
+++ b/public/index.html
@@ -1928,6 +1928,7 @@ input, select, textarea {
       if (row.addr.toLowerCase().indexOf(f) !== -1) return true;
       var lbl = (row.label || getLabelForAddress(row.addr)).toLowerCase();
       if (lbl && lbl.indexOf(f) !== -1) return true;
+      if (row.description && row.description.toLowerCase().indexOf(f) !== -1) return true;
       return false;
     }
 
@@ -1954,12 +1955,18 @@ input, select, textarea {
         // address lookup.
         var lbl = row.label || getLabelForAddress(row.addr);
         var pct = Math.round(row.level / 255 * 100);
+        // Security events carry a description ("Zone unsealed", "System armed
+        // (Day mode)"). A level percentage is meaningless for those, so the
+        // description takes over both the value and the bar cell.
+        var valueCells = row.description
+          ? '<td colspan="2">' + esc(row.description) + '</td>'
+          : '<td>' + esc(row.level) + ' (' + pct + '%)</td>' +
+            '<td class="event-bar-cell"><div class="event-bar-bg"><div class="event-bar-fill" style="width:' + pct + '%"></div></div></td>';
         html += '<tr data-addr="' + esc(row.addr) + '">' +
           '<td>' + esc(row.time) + '</td>' +
           '<td>' + esc(row.addr) + '</td>' +
           '<td>' + (lbl ? esc(lbl) : '<span style="color:var(--text-muted)">—</span>') + '</td>' +
-          '<td>' + esc(row.level) + ' (' + pct + '%)</td>' +
-          '<td class="event-bar-cell"><div class="event-bar-bg"><div class="event-bar-fill" style="width:' + pct + '%"></div></div></td>' +
+          valueCells +
           '</tr>';
       }
       tbody.innerHTML = html;
@@ -1994,13 +2001,18 @@ input, select, textarea {
       eventCount++;
       document.getElementById('eventCountBadge').textContent = eventCount;
 
+      // Panel-wide security events have no group, so the address is net/app.
+      var hasGroup = event.group !== null && event.group !== undefined && event.group !== '';
       var row = {
         ts: event.ts,
         time: formatTime(event.ts),
-        addr: event.network + '/' + event.app + '/' + event.group,
+        addr: hasGroup
+          ? event.network + '/' + event.app + '/' + event.group
+          : event.network + '/' + event.app,
         level: typeof event.level === 'number' ? event.level : 0,
         type: event.type || 'update',
-        label: event.label || ''
+        label: event.label || '',
+        description: event.description || ''
       };
       eventRows.push(row);
       if (eventRows.length > EVENT_MAX) {

--- a/src/applicationDecoders/securityDecoder.js
+++ b/src/applicationDecoders/securityDecoder.js
@@ -18,10 +18,13 @@ const { DEFAULT_CBUS_APP_SECURITY } = require('../constants');
  *   - arm_not_ready    → { kind:'arm_not_ready', …, zone } (zone names the blocker)
  *   - exit_delay_started → { kind:'exit_delay_started', … }
  *   - system_arm       → { kind:'system_arm', …, mode, modeName } (0-4; 0 = disarmed)
- *   - arm_failed       → { kind:'arm_failed', …, detail } (free-text, e.g. arm_failed_raised)
  *   - alarm_on / alarm_off → { kind:'alarm_on'|'alarm_off', … }
  *   - zone_isolated    → { kind:'zone_isolated', …, zone } (zone bypassed on arming)
- *   - fire_alarm       → { kind:'fire_alarm', …, detail }
+ *   - panel-wide trouble verbs → { kind:'panel_trouble', …, condition, active, detail }
+ *       mains_failure/mains_restored, low_battery/low_battery_corrected,
+ *       tamper_on/tamper_off, panic_activated/panic_off/panic_cleared, and the
+ *       detail-suffixed line_cut_alarm, arm_failed and fire_alarm (whose
+ *       "<verb>_raised"/"<verb>_cleared" argument carries the sense).
  *
  * Status report rendering: the spec (CBUS-APP/05 §5.5.1.20-21) packs 4 zones
  * per byte, 2 bits each (%00 sealed, %01 unsealed, %10 open, %11 short), but
@@ -63,6 +66,43 @@ const MAX_ZONE = 127; // zone numbers are $01-$7F (spec §5.5.1.11)
 // Verbs whose address carries a trailing zone (//PROJECT/<net>/<app>/<zone>).
 const ZONE_ADDRESS_VERBS = new Set([
     'zone_sealed', 'zone_unsealed', 'zone_open', 'zone_short', 'zone_isolated', 'arm_not_ready'
+]);
+
+/**
+ * Panel-wide trouble conditions, in display order.
+ */
+const PANEL_TROUBLE_CONDITIONS = ['mains', 'battery', 'tamper', 'panic', 'line', 'arm_failed', 'fire'];
+
+/**
+ * Verbs that name their own sense. Confirmed by the #42 captures except
+ * low_battery, tamper_on and panic_off/panic_cleared: the panel only ever
+ * emitted the other half of those three pairs (low_battery_corrected,
+ * tamper_off, panic_activated), so these names are inferred from the naming
+ * convention of the confirmed pairs. An inferred verb that never arrives costs
+ * nothing, and panic still recovers via the disarm-derived clear in
+ * securityPanelState.
+ */
+const PANEL_TROUBLE_VERBS = new Map([
+    ['mains_failure', { condition: 'mains', active: true }],
+    ['mains_restored', { condition: 'mains', active: false }],
+    ['low_battery', { condition: 'battery', active: true }],
+    ['low_battery_corrected', { condition: 'battery', active: false }],
+    ['tamper_on', { condition: 'tamper', active: true }],
+    ['tamper_off', { condition: 'tamper', active: false }],
+    ['panic_activated', { condition: 'panic', active: true }],
+    ['panic_off', { condition: 'panic', active: false }],
+    ['panic_cleared', { condition: 'panic', active: false }]
+]);
+
+/**
+ * Verbs whose active/cleared sense rides a "<verb>_raised" / "<verb>_cleared"
+ * detail argument rather than the verb name (confirmed for all three in the
+ * #42 captures). A bare verb with no detail means raised.
+ */
+const PANEL_TROUBLE_DETAIL_VERBS = new Map([
+    ['line_cut_alarm', 'line'],
+    ['arm_failed', 'arm_failed'],
+    ['fire_alarm', 'fire']
 ]);
 
 /**
@@ -245,11 +285,6 @@ function decodeLine(line) {
         return { kind: 'system_arm', network, application, mode: Number.isInteger(mode) ? mode : null, modeName, verb };
     }
 
-    if (verb === 'arm_failed' || verb === 'fire_alarm') {
-        // Alarm-style verbs may carry a free-text argument (e.g. arm_failed_raised).
-        return { kind: verb, network, application, detail: params.length > 0 ? params.join(' ') : null, verb };
-    }
-
     if (verb === 'alarm_on' || verb === 'alarm_off') {
         return { kind: verb, network, application, verb };
     }
@@ -258,7 +293,30 @@ function decodeLine(line) {
         return { kind: 'zone_isolated', network, application, zone, verb };
     }
 
+    // Panel-wide trouble conditions (mains, battery, tamper, panic, phone line,
+    // arm failure, fire). These become diagnostic binary_sensors; the raise and
+    // clear senses are resolved here so downstream code never parses verbs.
+    const named = PANEL_TROUBLE_VERBS.get(verb);
+    if (named) {
+        return {
+            kind: 'panel_trouble', network, application,
+            condition: named.condition, active: named.active, verb, detail: null
+        };
+    }
+
+    const detailCondition = PANEL_TROUBLE_DETAIL_VERBS.get(verb);
+    if (detailCondition) {
+        const detail = params.length > 0 ? params.join(' ') : null;
+        return {
+            kind: 'panel_trouble', network, application,
+            condition: detailCondition, active: !(detail && detail.endsWith('_cleared')), verb, detail
+        };
+    }
+
     return null;
 }
 
-module.exports = { appId, decodeLine, ZONE_STATE, ZONE_STATE_BY_CODE, ARM_MODE_BY_CODE };
+module.exports = {
+    appId, decodeLine, ZONE_STATE, ZONE_STATE_BY_CODE, ARM_MODE_BY_CODE,
+    PANEL_TROUBLE_CONDITIONS, PANEL_TROUBLE_VERBS, PANEL_TROUBLE_DETAIL_VERBS
+};

--- a/src/applicationDecoders/securityDecoder.js
+++ b/src/applicationDecoders/securityDecoder.js
@@ -1,5 +1,10 @@
 // @ts-check
 const { DEFAULT_CBUS_APP_SECURITY } = require('../constants');
+const {
+    PANEL_TROUBLE_CONDITIONS,
+    PANEL_TROUBLE_VERBS,
+    PANEL_TROUBLE_DETAIL_VERBS
+} = require('../securityPanelConditions');
 
 /**
  * C-Bus Security application (208 / $D0) line decoder.
@@ -68,42 +73,9 @@ const ZONE_ADDRESS_VERBS = new Set([
     'zone_sealed', 'zone_unsealed', 'zone_open', 'zone_short', 'zone_isolated', 'arm_not_ready'
 ]);
 
-/**
- * Panel-wide trouble conditions, in display order.
- */
-const PANEL_TROUBLE_CONDITIONS = ['mains', 'battery', 'tamper', 'panic', 'line', 'arm_failed', 'fire'];
-
-/**
- * Verbs that name their own sense. Confirmed by the #42 captures except
- * low_battery, tamper_on and panic_off/panic_cleared: the panel only ever
- * emitted the other half of those three pairs (low_battery_corrected,
- * tamper_off, panic_activated), so these names are inferred from the naming
- * convention of the confirmed pairs. An inferred verb that never arrives costs
- * nothing, and panic still recovers via the disarm-derived clear in
- * securityPanelState.
- */
-const PANEL_TROUBLE_VERBS = new Map([
-    ['mains_failure', { condition: 'mains', active: true }],
-    ['mains_restored', { condition: 'mains', active: false }],
-    ['low_battery', { condition: 'battery', active: true }],
-    ['low_battery_corrected', { condition: 'battery', active: false }],
-    ['tamper_on', { condition: 'tamper', active: true }],
-    ['tamper_off', { condition: 'tamper', active: false }],
-    ['panic_activated', { condition: 'panic', active: true }],
-    ['panic_off', { condition: 'panic', active: false }],
-    ['panic_cleared', { condition: 'panic', active: false }]
-]);
-
-/**
- * Verbs whose active/cleared sense rides a "<verb>_raised" / "<verb>_cleared"
- * detail argument rather than the verb name (confirmed for all three in the
- * #42 captures). A bare verb with no detail means raised.
- */
-const PANEL_TROUBLE_DETAIL_VERBS = new Map([
-    ['line_cut_alarm', 'line'],
-    ['arm_failed', 'arm_failed'],
-    ['fire_alarm', 'fire']
-]);
+// Panel-wide trouble conditions and their verbs live in securityPanelConditions
+// so the wire format, the HA entity metadata and the log wording for one
+// condition stay in a single record.
 
 /**
  * Parse a C-Bus address //PROJECT/<net>/<app>[/<zone>].
@@ -297,19 +269,18 @@ function decodeLine(line) {
     // arm failure, fire). These become diagnostic binary_sensors; the raise and
     // clear senses are resolved here so downstream code never parses verbs.
     const named = PANEL_TROUBLE_VERBS.get(verb);
-    if (named) {
-        return {
-            kind: 'panel_trouble', network, application,
-            condition: named.condition, active: named.active, verb, detail: null
-        };
-    }
-
     const detailCondition = PANEL_TROUBLE_DETAIL_VERBS.get(verb);
-    if (detailCondition) {
+    if (named || detailCondition) {
+        // Verbs in PANEL_TROUBLE_VERBS name their own sense; the rest carry it
+        // in a "<verb>_raised" / "<verb>_cleared" argument, where a bare verb
+        // with no argument means raised.
         const detail = params.length > 0 ? params.join(' ') : null;
         return {
             kind: 'panel_trouble', network, application,
-            condition: detailCondition, active: !(detail && detail.endsWith('_cleared')), verb, detail
+            condition: named ? named.condition : detailCondition,
+            active: named ? named.active : !(detail && detail.endsWith('_cleared')),
+            verb,
+            detail
         };
     }
 
@@ -318,5 +289,5 @@ function decodeLine(line) {
 
 module.exports = {
     appId, decodeLine, ZONE_STATE, ZONE_STATE_BY_CODE, ARM_MODE_BY_CODE,
-    PANEL_TROUBLE_CONDITIONS, PANEL_TROUBLE_VERBS, PANEL_TROUBLE_DETAIL_VERBS
+    PANEL_TROUBLE_CONDITIONS
 };

--- a/src/bridgeInitializationService.js
+++ b/src/bridgeInitializationService.js
@@ -113,11 +113,7 @@ class BridgeInitializationService {
 
         if (getallNetworks.length > 0 && this.settings.getallonstart) {
             this._log(`Getting all initial values for networks: ${getallNetworks.join(', ')}...`);
-            for (const netapp of getallNetworks) {
-                this.commandQueue.add(
-                    `${CGATE_CMD_GET} //${this.settings.cbusname}/${netapp}/* ${CGATE_PARAM_LEVEL}${NEWLINE}`
-                );
-            }
+            this.sendGetallLevels(getallNetworks);
         }
 
         if (getallNetworks.length > 0 && (this.settings.getallperiod || this.settings.getall_app_periods)) {
@@ -126,7 +122,7 @@ class BridgeInitializationService {
 
         // Security panels don't answer lighting-style getall (spec §5.9), so
         // the security app syncs zone state via dedicated status requests.
-        this._sendSecurityStatusRequests();
+        this.sendSecurityStatusRequests();
 
         // Monitor CNI/PCI connectivity per network (independent of getall).
         this._startNetworkInterfaceMonitoring();
@@ -248,9 +244,7 @@ class BridgeInitializationService {
         this._log(`Starting periodic 'get all' for ${networkAppPath} every ${intervalMs / 1000} seconds.`);
         const handle = setInterval(() => {
             this.logger.debug(`Getting all periodic values for ${networkAppPath}...`);
-            this.commandQueue.add(
-                `${CGATE_CMD_GET} //${this.settings.cbusname}/${networkAppPath}/* ${CGATE_PARAM_LEVEL}${NEWLINE}`
-            );
+            this.commandQueue.add(this._getallLevelsCommand(networkAppPath));
         }, intervalMs).unref();
         this._perAppTimers.set(networkAppPath, handle);
     }
@@ -489,7 +483,35 @@ class BridgeInitializationService {
      * being in ha_discovery_networks.
      * @private
      */
-    _sendSecurityStatusRequests() {
+    /**
+     * The C-Gate wire command that asks for every group level on one
+     * network/app pair. Single source for the syntax, including the trailing
+     * newline, which all three getall paths (start, periodic, resync) share.
+     *
+     * @param {string} netapp - "network/app", e.g. "254/56"
+     * @returns {string}
+     * @private
+     */
+    _getallLevelsCommand(netapp) {
+        return `${CGATE_CMD_GET} //${this.settings.cbusname}/${netapp}/* ${CGATE_PARAM_LEVEL}${NEWLINE}`;
+    }
+
+    /**
+     * Queue a level getall for each configured network/app pair.
+     *
+     * @param {string[]|null} [netapps] - pairs to request; resolved from settings when omitted
+     * @param {{priority?: string}} [options] - command queue options
+     * @returns {string[]} the pairs actually queued
+     */
+    sendGetallLevels(netapps = null, options = {}) {
+        const pairs = netapps || this._resolveGetallNetworks();
+        for (const netapp of pairs) {
+            this.commandQueue.add(this._getallLevelsCommand(netapp), options);
+        }
+        return pairs;
+    }
+
+    sendSecurityStatusRequests(trigger = 'connect') {
         const appId = this.settings.cbus_security_app_id;
         if (!appId || String(appId) === '0') return;
         const networks = this.settings.ha_discovery_networks;
@@ -497,7 +519,7 @@ class BridgeInitializationService {
         const handler = this._getSecurityEventHandler ? this._getSecurityEventHandler() : null;
         if (!handler) return;
         for (const network of networks) {
-            handler.requestStatusSync(network, 'connect');
+            handler.requestStatusSync(network, trigger);
         }
     }
 

--- a/src/cgateWebBridge.js
+++ b/src/cgateWebBridge.js
@@ -10,6 +10,7 @@ const ConnectionManager = require('./connectionManager');
 const EventPublisher = require('./eventPublisher');
 const AirconEventHandler = require('./airconEventHandler');
 const SecurityEventHandler = require('./securityEventHandler');
+const StateResyncCoordinator = require('./stateResyncCoordinator');
 const CommandResponseProcessor = require('./commandResponseProcessor');
 const DeviceStateManager = require('./deviceStateManager');
 const LabelLoader = require('./labelLoader');
@@ -247,6 +248,17 @@ class CgateWebBridge {
             onEventLog: this._onEventLog
         });
 
+        // Republishes state after a Home Assistant or MQTT broker restart
+        // (issue #44). Neither event restarts the bridge, so nothing else would.
+        this.stateResyncCoordinator = new StateResyncCoordinator({
+            settings: this.settings,
+            commandQueue: this.cgateCommandQueue,
+            logger: this.logger,
+            getHaDiscovery: this._getHaDiscovery,
+            getSecurityEventHandler: () => this.securityEventHandler,
+            initializationService: this.initializationService
+        });
+
         // Tracks CNI/PCI connectivity per C-Bus network (see networkInterfaceMonitor).
         this.networkInterfaceMonitor = new NetworkInterfaceMonitor({ logger: this.logger });
 
@@ -403,8 +415,26 @@ class CgateWebBridge {
             }
         });
 
-        // MQTT message routing
-        this.mqttManager.on('message', (topic, payload) => this.mqttCommandRouter.routeMessage(topic, payload));
+        // MQTT message routing. The HA birth topic is intercepted here rather
+        // than in the command router: it isn't a cbus/write command, and an
+        // 'online' payload means Home Assistant restarted and has lost every
+        // entity state it was holding (issue #44).
+        this.mqttManager.on('message', (topic, payload) => {
+            if (topic === this.mqttManager.haStatusTopic) {
+                if (String(payload).trim().toLowerCase() === 'online') {
+                    this.logger.info('Home Assistant came online; resyncing entity state');
+                    this.stateResyncCoordinator.requestResync('ha-birth');
+                }
+                return;
+            }
+            this.mqttCommandRouter.routeMessage(topic, payload);
+        });
+
+        // A mid-session broker reconnect may have dropped the retained discovery
+        // configs along with the state, so this path republishes both.
+        this.mqttManager.on('reconnect', () => {
+            this.stateResyncCoordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+        });
 
         // Data processing handlers - pass connection for per-connection line processing
         this.commandConnectionPool.on('data', (data, connection) => this._handleCommandData(data, connection));
@@ -514,6 +544,7 @@ class CgateWebBridge {
         this.mqttManager.removeAllListeners();
 
         this.initializationService.stop();
+        this.stateResyncCoordinator.dispose();
         this.haBridgeDiagnostics.stop();
         this.staleDeviceDetector.stop();
 

--- a/src/cgateWebBridge.js
+++ b/src/cgateWebBridge.js
@@ -252,10 +252,8 @@ class CgateWebBridge {
         // (issue #44). Neither event restarts the bridge, so nothing else would.
         this.stateResyncCoordinator = new StateResyncCoordinator({
             settings: this.settings,
-            commandQueue: this.cgateCommandQueue,
             logger: this.logger,
             getHaDiscovery: this._getHaDiscovery,
-            getSecurityEventHandler: () => this.securityEventHandler,
             initializationService: this.initializationService
         });
 
@@ -415,26 +413,19 @@ class CgateWebBridge {
             }
         });
 
-        // MQTT message routing. The HA birth topic is intercepted here rather
-        // than in the command router: it isn't a cbus/write command, and an
-        // 'online' payload means Home Assistant restarted and has lost every
-        // entity state it was holding (issue #44).
-        this.mqttManager.on('message', (topic, payload) => {
-            if (topic === this.mqttManager.haStatusTopic) {
-                if (String(payload).trim().toLowerCase() === 'online') {
-                    this.logger.info('Home Assistant came online; resyncing entity state');
-                    this.stateResyncCoordinator.requestResync('ha-birth');
-                }
-                return;
-            }
-            this.mqttCommandRouter.routeMessage(topic, payload);
+        // MQTT message routing
+        this.mqttManager.on('message', (topic, payload) => this.mqttCommandRouter.routeMessage(topic, payload));
+
+        // Home Assistant restarted: it has lost every entity state it was
+        // holding, and the add-on kept running, so nothing else would resend it.
+        this.mqttManager.on('haOnline', () => {
+            this.logger.info('Home Assistant came online; resyncing entity state');
+            this.stateResyncCoordinator.requestResync('ha-birth');
         });
 
         // A mid-session broker reconnect may have dropped the retained discovery
         // configs along with the state, so this path republishes both.
-        this.mqttManager.on('reconnect', () => {
-            this.stateResyncCoordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
-        });
+        this.mqttManager.on('reconnect', () => this.stateResyncCoordinator.requestResync('mqtt-reconnect'));
 
         // Data processing handlers - pass connection for per-connection line processing
         this.commandConnectionPool.on('data', (data, connection) => this._handleCommandData(data, connection));

--- a/src/constants.js
+++ b/src/constants.js
@@ -108,6 +108,9 @@ const HA_COMPONENT_CLIMATE = 'climate';
 const HA_COMPONENT_SENSOR = 'sensor';
 const HA_COMPONENT_BINARY_SENSOR = 'binary_sensor';
 const HA_DISCOVERY_SUFFIX = 'config';
+// Fallback when ha_discovery_prefix is unset. defaultSettings and ConfigLoader
+// both supply it, so this only matters for directly-constructed collaborators.
+const HA_DISCOVERY_PREFIX_DEFAULT = 'homeassistant';
 
 // HA Device Classes
 const HA_DEVICE_CLASS_SHUTTER = 'shutter';
@@ -258,6 +261,7 @@ module.exports = {
     HA_COMPONENT_SENSOR,
     HA_COMPONENT_BINARY_SENSOR,
     HA_DISCOVERY_SUFFIX,
+    HA_DISCOVERY_PREFIX_DEFAULT,
     HA_DEVICE_CLASS_SHUTTER,
     HA_DEVICE_CLASS_OUTLET,
     HA_DEVICE_VIA,

--- a/src/defaultSettings.js
+++ b/src/defaultSettings.js
@@ -127,6 +127,19 @@ const defaultSettings = {
     // Bound on retained MQTT publishes queued while the broker is unreachable.
     // Newest-wins per topic; oldest entries are evicted when full.
     mqttPendingPublishMaxEntries: 1000,
+    // Republish entity state after Home Assistant or the MQTT broker restarts
+    // (issue #44). Neither looks like a bridge restart, so without this HA comes
+    // back with entities stuck unknown until the next physical C-Bus event.
+    // Both default on: this is a fix, not an opt-in feature.
+    stateResyncOnHaRestart: true,
+    stateResyncOnMqttReconnect: true,
+    // Collapse near-simultaneous resync triggers (a broker bounce that also
+    // restarts HA) into a single pass.
+    stateResyncDebounceMs: 5000,
+    // Home Assistant's birth/will topic. Null derives it from
+    // ha_discovery_prefix, which is 'homeassistant/status' by default and
+    // follows the prefix when a user has changed it.
+    haStatusTopic: null,
     // How often (ms) to poll each C-Bus network's CNI/PCI interface state so a
     // dropout between C-Gate and the C-Bus network surfaces on the status page.
     // Set to 0 to disable. Default 30s.

--- a/src/eventPublisher.js
+++ b/src/eventPublisher.js
@@ -439,6 +439,15 @@ class EventPublisher {
                     this.mqttOptions
                 );
             }
+        } else if (reading.kind === 'security_panel') {
+            // Panel-wide trouble condition (app 208): ON means the trouble is
+            // present. `group` is the "panel/<condition>" path segment, so the
+            // base already addresses the right topic.
+            this._publishIfNeeded(
+                `${base}/${MQTT_TOPIC_SUFFIX_STATE}`,
+                reading.active ? MQTT_STATE_ON : MQTT_STATE_OFF,
+                this.mqttOptions
+            );
         }
     }
 

--- a/src/haDiscovery.js
+++ b/src/haDiscovery.js
@@ -101,6 +101,11 @@ class HaDiscovery {
         // runs. Tracks "network/app/zone" keys already published this session.
         this._securityZoneSeen = new Set();
 
+        // Security panel-wide trouble sensors (mains, battery, tamper, panic,
+        // phone line, arm failure, fire), announced as one group per network on
+        // first security traffic. Tracks "network/app/panel" keys.
+        this._securityPanelSeen = new Set();
+
         // Network IDs whose CNI/PCI connectivity binary_sensor config has been
         // published this session (event-driven, idempotent).
         this._cniDiscoverySeen = new Set();

--- a/src/haDiscovery.js
+++ b/src/haDiscovery.js
@@ -8,6 +8,10 @@ const {
     HA_DISCOVERY_SUFFIX
 } = require('./constants');
 
+// Discovery config topics end in this; used to recognise them in the _publish
+// wrapper that records payloads for replay after a broker restart.
+const CONFIG_TOPIC_SUFFIX = `/${HA_DISCOVERY_SUFFIX}`;
+
 /**
  * Methods mixed into HaDiscovery.prototype from haDiscoveryTreeSession.js and
  * haDiscoveryPublishers.js at module load (see the Object.assign calls at the
@@ -40,8 +44,9 @@ class HaDiscovery {
         // publish a config, so the cache cannot drift out of sync with them.
         // Bounded by entity count: a few hundred payloads of roughly 500 bytes.
         this._publishedConfigPayloads = new Map();
+        this._rawPublish = publishFn;
         this._publish = (topic, payload, options) => {
-            if (typeof topic === 'string' && topic.endsWith(`/${HA_DISCOVERY_SUFFIX}`)) {
+            if (typeof topic === 'string' && topic.endsWith(CONFIG_TOPIC_SUFFIX)) {
                 // An empty payload is a retraction — forget it, don't replay it.
                 if (payload) this._publishedConfigPayloads.set(topic, payload);
                 else this._publishedConfigPayloads.delete(topic);
@@ -147,7 +152,9 @@ class HaDiscovery {
     republishDiscoveryConfigs() {
         let count = 0;
         for (const [topic, payload] of this._publishedConfigPayloads) {
-            this._publish(topic, payload, MQTT_RETAINED_STATE_OPTIONS);
+            // Raw publish: going through this._publish would re-record each
+            // entry with the value we are iterating, for no benefit.
+            this._rawPublish(topic, payload, MQTT_RETAINED_STATE_OPTIONS);
             count++;
         }
         if (count > 0) this.logger.info(`Republished ${count} HA Discovery config(s)`);

--- a/src/haDiscovery.js
+++ b/src/haDiscovery.js
@@ -34,7 +34,20 @@ class HaDiscovery {
      */
     constructor(settings, publishFn, sendCommandFn, labelData = null) {
         this.settings = settings;
-        this._publish = publishFn;
+        // Retained discovery config payloads by topic, so they can be replayed
+        // after an MQTT broker restart drops them (issue #44). Recorded in the
+        // _publish wrapper below rather than at each of the ~16 call sites that
+        // publish a config, so the cache cannot drift out of sync with them.
+        // Bounded by entity count: a few hundred payloads of roughly 500 bytes.
+        this._publishedConfigPayloads = new Map();
+        this._publish = (topic, payload, options) => {
+            if (typeof topic === 'string' && topic.endsWith(`/${HA_DISCOVERY_SUFFIX}`)) {
+                // An empty payload is a retraction — forget it, don't replay it.
+                if (payload) this._publishedConfigPayloads.set(topic, payload);
+                else this._publishedConfigPayloads.delete(topic);
+            }
+            return publishFn(topic, payload, options);
+        };
         this._sendCommand = sendCommandFn;
         this._applyLabelData(labelData);
 
@@ -119,6 +132,26 @@ class HaDiscovery {
         // connectivity sensors vanish whenever a tree refresh runs after they
         // were announced. Tracked here so the cleanup can skip them.
         this._eventDrivenDiscoveryTopics = new Set();
+    }
+
+    /**
+     * Re-send every discovery config published this session, retained.
+     *
+     * A broker restart without retained-message persistence loses the configs,
+     * and Home Assistant then has no entities at all until the next tree run.
+     * Replaying the cached payloads restores them exactly, without re-running
+     * TREEXML and its retry/epoch machinery (issue #44).
+     *
+     * @returns {number} configs republished
+     */
+    republishDiscoveryConfigs() {
+        let count = 0;
+        for (const [topic, payload] of this._publishedConfigPayloads) {
+            this._publish(topic, payload, MQTT_RETAINED_STATE_OPTIONS);
+            count++;
+        }
+        if (count > 0) this.logger.info(`Republished ${count} HA Discovery config(s)`);
+        return count;
     }
 
     /**

--- a/src/haDiscoveryPublishers.js
+++ b/src/haDiscoveryPublishers.js
@@ -47,32 +47,7 @@ const {
     HA_MODEL_TRIGGER,
     entityIdFields
 } = require('./constants');
-const { PANEL_TROUBLE_CONDITIONS } = require('./applicationDecoders/securityDecoder');
-
-/**
- * Display names and HA device classes for the panel trouble sensors. These are
- * entity names on a shared device, so they read as short attributes of the
- * panel ("Mains power") rather than repeating the device name.
- */
-const PANEL_CONDITION_NAMES = {
-    mains: 'Mains power',
-    battery: 'Battery',
-    tamper: 'Tamper',
-    panic: 'Panic',
-    line: 'Phone line',
-    arm_failed: 'Arm failed',
-    fire: 'Fire alarm'
-};
-
-const PANEL_CONDITION_DEVICE_CLASSES = {
-    mains: 'problem',
-    battery: 'battery',
-    tamper: 'tamper',
-    panic: 'safety',
-    line: 'problem',
-    arm_failed: 'problem',
-    fire: 'smoke'
-};
+const { PANEL_CONDITIONS } = require('./securityPanelConditions');
 
 class _HaDiscoveryPublishers {
     // Host-provided instance state. This class is never instantiated: its
@@ -545,9 +520,7 @@ class _HaDiscoveryPublishers {
             this.logger.debug(`Excluding temperature group ${key} from discovery`);
             const excludedUniqueId = `cgateweb_${network}_${appId}_${group}`;
             const excludedTopic = `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_SENSOR}/${excludedUniqueId}/${HA_DISCOVERY_SUFFIX}`;
-            this._publish(excludedTopic, '', MQTT_RETAINED_STATE_OPTIONS);
-            this._publishedTopics.delete(excludedTopic);
-            this._eventDrivenDiscoveryTopics.delete(excludedTopic);
+            this._retractEventDrivenConfig(excludedTopic);
             this._temperatureSeen.add(key); // don't re-check on every event
             return false;
         }
@@ -630,9 +603,7 @@ class _HaDiscoveryPublishers {
             this.logger.debug(`Excluding security zone ${key} from discovery`);
             const excludedUniqueId = `cgateweb_${network}_${appId}_${zone}`;
             const excludedTopic = `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_BINARY_SENSOR}/${excludedUniqueId}/${HA_DISCOVERY_SUFFIX}`;
-            this._publish(excludedTopic, '', MQTT_RETAINED_STATE_OPTIONS);
-            this._publishedTopics.delete(excludedTopic);
-            this._eventDrivenDiscoveryTopics.delete(excludedTopic);
+            this._retractEventDrivenConfig(excludedTopic);
             this._securityZoneSeen.add(key); // don't re-check on every event
             return false;
         }
@@ -720,11 +691,10 @@ class _HaDiscoveryPublishers {
 
         if (this.exclude.has(key)) {
             this.logger.debug(`Excluding security panel ${network}/${appId} from discovery`);
-            for (const condition of PANEL_TROUBLE_CONDITIONS) {
-                const excludedTopic = this._securityPanelTopic(String(network), String(appId), condition);
-                this._publish(excludedTopic, '', MQTT_RETAINED_STATE_OPTIONS);
-                this._publishedTopics.delete(excludedTopic);
-                this._eventDrivenDiscoveryTopics.delete(excludedTopic);
+            for (const condition of PANEL_CONDITIONS) {
+                this._retractEventDrivenConfig(
+                    this._securityPanelTopic(this._securityPanelUniqueId(String(network), String(appId), condition.id))
+                );
             }
             this._securityPanelSeen.add(key); // don't re-check on every event
             return false;
@@ -736,43 +706,53 @@ class _HaDiscoveryPublishers {
     }
 
     /**
-     * Discovery config topic for one panel trouble condition.
+     * unique_id for one panel trouble condition. The discovery topic embeds this,
+     * so both must come from here or a retraction would target a topic HA never
+     * saw and orphan the entity.
      *
      * @param {string} networkId
      * @param {string} appId
-     * @param {string} condition
+     * @param {string} conditionId
      * @returns {string}
      * @private
      */
-    _securityPanelTopic(networkId, appId, condition) {
-        const uniqueId = `cgateweb_${networkId}_${appId}_panel_${condition}`;
+    _securityPanelUniqueId(networkId, appId, conditionId) {
+        return `cgateweb_${networkId}_${appId}_panel_${conditionId}`;
+    }
+
+    /**
+     * @param {string} uniqueId
+     * @returns {string}
+     * @private
+     */
+    _securityPanelTopic(uniqueId) {
         return `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_BINARY_SENSOR}/${uniqueId}/${HA_DISCOVERY_SUFFIX}`;
     }
 
     /**
-     * Build and publish the seven panel trouble binary_sensor payloads. State
-     * comes from securityEventHandler via
+     * Build and publish the panel trouble binary_sensor payloads, one per
+     * condition. State comes from securityEventHandler via
      * cbus/read/{net}/{app}/panel/{condition}/state (ON = trouble present).
      *
      * @private
      */
     _createSecurityPanelDiscovery(networkId, appId) {
         const deviceName = `C-Bus Security Panel ${networkId}/${appId}`;
-        for (const condition of PANEL_TROUBLE_CONDITIONS) {
-            const uniqueId = `cgateweb_${networkId}_${appId}_panel_${condition}`;
-            const discoveryTopic = this._securityPanelTopic(networkId, appId, condition);
-            const readBase = `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/panel/${condition}`;
+        for (const condition of PANEL_CONDITIONS) {
+            const uniqueId = this._securityPanelUniqueId(networkId, appId, condition.id);
+            const discoveryTopic = this._securityPanelTopic(uniqueId);
+            const readBase = `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/panel/${condition.id}`;
 
             const payload = {
-                // Seven entities on one shared device, so each needs its own
+                // Several entities on one shared device, so each needs its own
                 // name (zones use null, taking the device name instead).
-                name: PANEL_CONDITION_NAMES[condition],
+                name: condition.name,
                 unique_id: uniqueId,
 
                 state_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_STATE}`,
                 payload_on: MQTT_STATE_ON,
                 payload_off: MQTT_STATE_OFF,
-                device_class: PANEL_CONDITION_DEVICE_CLASSES[condition],
+                device_class: condition.deviceClass,
                 entity_category: 'diagnostic',
 
                 qos: 0,
@@ -789,7 +769,21 @@ class _HaDiscoveryPublishers {
             this._eventDrivenDiscoveryTopics.add(discoveryTopic);
             this.discoveryCount++;
         }
-        this.logger.info(`Security panel binary_sensors published: ${networkId}/${appId} (${PANEL_TROUBLE_CONDITIONS.length} conditions)`);
+        this.logger.info(`Security panel binary_sensors published: ${networkId}/${appId} (${PANEL_CONDITIONS.length} conditions)`);
+    }
+
+    /**
+     * Retract one event-driven discovery config: clear the retained message and
+     * forget it, so a later tree run's stale cleanup doesn't try to clear it
+     * again and the replay cache doesn't resurrect it on a broker reconnect.
+     *
+     * @param {string} topic
+     * @private
+     */
+    _retractEventDrivenConfig(topic) {
+        this._publish(topic, '', MQTT_RETAINED_STATE_OPTIONS);
+        this._publishedTopics.delete(topic);
+        this._eventDrivenDiscoveryTopics.delete(topic);
     }
 
     /**
@@ -820,9 +814,7 @@ class _HaDiscoveryPublishers {
             // sensors) so they disappear from HA once the user excludes it (e.g.
             // a PAC/controller mirroring the real thermostats).
             for (const topic of this._nativeAirconDiscoveryTopics(network, appId, sourceUnit)) {
-                this._publish(topic, '', MQTT_RETAINED_STATE_OPTIONS);
-                this._publishedTopics.delete(topic);
-                this._eventDrivenDiscoveryTopics.delete(topic);
+                this._retractEventDrivenConfig(topic);
             }
             this._nativeAirconSeen.add(key); // don't re-check on every event
             return false;

--- a/src/haDiscoveryPublishers.js
+++ b/src/haDiscoveryPublishers.js
@@ -47,6 +47,32 @@ const {
     HA_MODEL_TRIGGER,
     entityIdFields
 } = require('./constants');
+const { PANEL_TROUBLE_CONDITIONS } = require('./applicationDecoders/securityDecoder');
+
+/**
+ * Display names and HA device classes for the panel trouble sensors. These are
+ * entity names on a shared device, so they read as short attributes of the
+ * panel ("Mains power") rather than repeating the device name.
+ */
+const PANEL_CONDITION_NAMES = {
+    mains: 'Mains power',
+    battery: 'Battery',
+    tamper: 'Tamper',
+    panic: 'Panic',
+    line: 'Phone line',
+    arm_failed: 'Arm failed',
+    fire: 'Fire alarm'
+};
+
+const PANEL_CONDITION_DEVICE_CLASSES = {
+    mains: 'problem',
+    battery: 'battery',
+    tamper: 'tamper',
+    panic: 'safety',
+    line: 'problem',
+    arm_failed: 'problem',
+    fire: 'smoke'
+};
 
 class _HaDiscoveryPublishers {
     // Host-provided instance state. This class is never instantiated: its
@@ -98,6 +124,9 @@ class _HaDiscoveryPublishers {
 
     /** @type {Set<string>} */
     _securityZoneSeen;
+
+    /** @type {Set<string>} */
+    _securityPanelSeen;
 
     /** @type {Set<string>} */
     _currentRunTopics;
@@ -664,6 +693,103 @@ class _HaDiscoveryPublishers {
         this._eventDrivenDiscoveryTopics.add(discoveryTopic);
         this.discoveryCount++;
         this.logger.info(`Security zone binary_sensor published: ${networkId}/${appId}/${zone} (${finalLabel})`);
+    }
+
+    /**
+     * Announce the seven panel-wide trouble binary_sensors for a network the
+     * first time any security traffic is seen on it. Follows the
+     * ensureSecurityZoneDiscovery contract: idempotent Seen set, `exclude`
+     * honored with retraction, topics registered in _publishedTopics and
+     * _eventDrivenDiscoveryTopics so tree-run stale cleanup skips them.
+     *
+     * Unlike zones (one HA device each), all seven share a single "C-Bus
+     * Security Panel" device: they describe the panel's health, not seven
+     * separate pieces of hardware. entity_category 'diagnostic' keeps them off
+     * auto-generated dashboards.
+     *
+     * @param {string|number} network
+     * @param {string|number} appId - security app id (e.g. 208)
+     * @returns {boolean} true if the entities were published this call
+     */
+    ensureSecurityPanelDiscovery(network, appId) {
+        if (!this.settings.ha_discovery_enabled) return false;
+        if (network === null || network === undefined || appId === null || appId === undefined) return false;
+
+        const key = `${network}/${appId}/panel`;
+        if (this._securityPanelSeen.has(key)) return false;
+
+        if (this.exclude.has(key)) {
+            this.logger.debug(`Excluding security panel ${network}/${appId} from discovery`);
+            for (const condition of PANEL_TROUBLE_CONDITIONS) {
+                const excludedTopic = this._securityPanelTopic(String(network), String(appId), condition);
+                this._publish(excludedTopic, '', MQTT_RETAINED_STATE_OPTIONS);
+                this._publishedTopics.delete(excludedTopic);
+                this._eventDrivenDiscoveryTopics.delete(excludedTopic);
+            }
+            this._securityPanelSeen.add(key); // don't re-check on every event
+            return false;
+        }
+
+        this._createSecurityPanelDiscovery(String(network), String(appId));
+        this._securityPanelSeen.add(key);
+        return true;
+    }
+
+    /**
+     * Discovery config topic for one panel trouble condition.
+     *
+     * @param {string} networkId
+     * @param {string} appId
+     * @param {string} condition
+     * @returns {string}
+     * @private
+     */
+    _securityPanelTopic(networkId, appId, condition) {
+        const uniqueId = `cgateweb_${networkId}_${appId}_panel_${condition}`;
+        return `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_BINARY_SENSOR}/${uniqueId}/${HA_DISCOVERY_SUFFIX}`;
+    }
+
+    /**
+     * Build and publish the seven panel trouble binary_sensor payloads. State
+     * comes from securityEventHandler via
+     * cbus/read/{net}/{app}/panel/{condition}/state (ON = trouble present).
+     *
+     * @private
+     */
+    _createSecurityPanelDiscovery(networkId, appId) {
+        const deviceName = `C-Bus Security Panel ${networkId}/${appId}`;
+        for (const condition of PANEL_TROUBLE_CONDITIONS) {
+            const uniqueId = `cgateweb_${networkId}_${appId}_panel_${condition}`;
+            const discoveryTopic = this._securityPanelTopic(networkId, appId, condition);
+            const readBase = `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/panel/${condition}`;
+
+            const payload = {
+                // Seven entities on one shared device, so each needs its own
+                // name (zones use null, taking the device name instead).
+                name: PANEL_CONDITION_NAMES[condition],
+                unique_id: uniqueId,
+
+                state_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_STATE}`,
+                payload_on: MQTT_STATE_ON,
+                payload_off: MQTT_STATE_OFF,
+                device_class: PANEL_CONDITION_DEVICE_CLASSES[condition],
+                entity_category: 'diagnostic',
+
+                qos: 0,
+                device: buildDeviceBlock({
+                    identifiers: [`cgateweb_${networkId}_${appId}_panel`],
+                    name: deviceName,
+                    model: 'C-Bus Security Panel'
+                }),
+                origin: buildOriginBlock()
+            };
+
+            this._publish(discoveryTopic, JSON.stringify(payload), MQTT_RETAINED_STATE_OPTIONS);
+            this._publishedTopics.add(discoveryTopic);
+            this._eventDrivenDiscoveryTopics.add(discoveryTopic);
+            this.discoveryCount++;
+        }
+        this.logger.info(`Security panel binary_sensors published: ${networkId}/${appId} (${PANEL_TROUBLE_CONDITIONS.length} conditions)`);
     }
 
     /**

--- a/src/mqttManager.js
+++ b/src/mqttManager.js
@@ -9,7 +9,8 @@ const {
     MQTT_TOPIC_STATUS,
     MQTT_PAYLOAD_STATUS_ONLINE,
     MQTT_PAYLOAD_STATUS_OFFLINE,
-    MQTT_ERROR_AUTH
+    MQTT_ERROR_AUTH,
+    HA_DISCOVERY_PREFIX_DEFAULT
 } = require('./constants');
 
 /**
@@ -63,6 +64,10 @@ class MqttManager extends EventEmitter {
         // successfully connected at least once (true mid-session disconnect).
         this._hasConnectedOnce = false;
         this._authFailureLogged = false;
+        // Memoized: ha_discovery_prefix is not hot-reloadable, and the getter is
+        // consulted for every inbound message.
+        /** @type {string|null} */
+        this._haStatusTopic = null;
 
         // Pre-connect / disconnect publish queue. Retained-state publishes
         // attempted while the broker is unreachable are queued here and
@@ -346,9 +351,12 @@ class MqttManager extends EventEmitter {
      * @returns {string}
      */
     get haStatusTopic() {
-        if (this.settings.haStatusTopic) return String(this.settings.haStatusTopic);
-        const prefix = this.settings.ha_discovery_prefix || 'homeassistant';
-        return `${prefix}/status`;
+        if (this._haStatusTopic === null) {
+            this._haStatusTopic = this.settings.haStatusTopic
+                ? String(this.settings.haStatusTopic)
+                : `${this.settings.ha_discovery_prefix || HA_DISCOVERY_PREFIX_DEFAULT}/status`;
+        }
+        return this._haStatusTopic;
     }
 
     _handleClose() {
@@ -441,6 +449,16 @@ class MqttManager extends EventEmitter {
             return;
         }
         const payload = message.toString();
+
+        // Home Assistant's birth/will topic. Translated into a semantic event
+        // here because this is the component that owns the topic and the payload
+        // convention; consumers shouldn't have to string-match a topic they
+        // don't own. Not forwarded as a generic 'message' — it is not a command.
+        if (topic === this.haStatusTopic) {
+            if (payload.trim().toLowerCase() === 'online') this.emit('haOnline');
+            return;
+        }
+
         this.emit('message', topic, payload);
     }
 

--- a/src/mqttManager.js
+++ b/src/mqttManager.js
@@ -43,6 +43,8 @@ class MqttManager extends EventEmitter {
      * @param {string} [settings.mqttCertFile] - Path to client certificate file for TLS
      * @param {string} [settings.mqttKeyFile] - Path to client private key file for TLS
      * @param {boolean} [settings.mqttRejectUnauthorized] - Set false to disable TLS certificate verification
+     * @param {string|null} [settings.haStatusTopic] - Home Assistant birth/will topic override (default `<prefix>/status`)
+     * @param {string} [settings.ha_discovery_prefix] - HA Discovery prefix, used to derive the birth topic
      * @param {{ type?: string }} [settings._environment] - Runtime environment descriptor (internal)
      */
     constructor(settings) {
@@ -285,6 +287,11 @@ class MqttManager extends EventEmitter {
     _handleConnect() {
         this._connecting = false;
         this.connected = true;
+        // Captured before the flag is set: a true mid-session reconnect means
+        // the broker restarted or dropped us, which may have taken the retained
+        // discovery configs with it (issue #44). A first connect needs no
+        // resync — startup's own getall covers it.
+        const isReconnect = this._hasConnectedOnce;
         this._hasConnectedOnce = true;
         this._authFailureLogged = false;
         this.logger.info(`CONNECTED TO MQTT BROKER: ${this.settings.mqtt}`);
@@ -315,8 +322,33 @@ class MqttManager extends EventEmitter {
                 this.logger.info(`Subscribed to MQTT topic: ${MQTT_TOPIC_PREFIX_WRITE}/#`);
             }
         });
-        
+
+        // Home Assistant's birth message, so a HA restart can trigger a state
+        // resync (issue #44). HA restarting does not restart the add-on, so this
+        // is the only signal that its entity states need resending.
+        this.subscribe(this.haStatusTopic, (err) => {
+            if (err) {
+                this.logger.error(`MQTT Subscription error:`, { error: err });
+            } else {
+                this.logger.info(`Subscribed to MQTT topic: ${this.haStatusTopic}`);
+            }
+        });
+
         this.emit('connect');
+        if (isReconnect) this.emit('reconnect');
+    }
+
+    /**
+     * Home Assistant's birth/will topic. Defaults to `<prefix>/status`, which is
+     * 'homeassistant/status' out of the box and follows ha_discovery_prefix when
+     * a user has changed it; overridable via haStatusTopic.
+     *
+     * @returns {string}
+     */
+    get haStatusTopic() {
+        if (this.settings.haStatusTopic) return String(this.settings.haStatusTopic);
+        const prefix = this.settings.ha_discovery_prefix || 'homeassistant';
+        return `${prefix}/status`;
     }
 
     _handleClose() {

--- a/src/securityEventHandler.js
+++ b/src/securityEventHandler.js
@@ -6,6 +6,21 @@ const { buildSecurityStatusRequest } = require('./securityCommand');
 const { NEWLINE } = require('./constants');
 
 /**
+ * User-facing wording for each panel trouble condition, in both senses. The
+ * panel's own `_raised`/`_cleared` argument is deliberately not echoed into the
+ * log line: the sense is already carried by the wording.
+ */
+const PANEL_TROUBLE_TEXT = {
+    mains: { raised: 'Mains power failure', cleared: 'Mains power restored' },
+    battery: { raised: 'Battery low', cleared: 'Battery restored' },
+    tamper: { raised: 'Tamper detected', cleared: 'Tamper cleared' },
+    panic: { raised: 'Panic activated', cleared: 'Panic cleared' },
+    line: { raised: 'Phone line cut', cleared: 'Phone line restored' },
+    arm_failed: { raised: 'Arm failed', cleared: 'Arm failure cleared' },
+    fire: { raised: 'Fire alarm', cleared: 'Fire alarm cleared' }
+};
+
+/**
  * Decoded security reading produced by securityDecoder.decodeLine. The exact
  * fields vary by `kind`; only the ones this handler touches are listed.
  * @typedef {Object} SecurityReading
@@ -22,7 +37,9 @@ const { NEWLINE } = require('./constants');
  * @property {number|null} [mode] - system_arm only
  * @property {string|null} [modeName] - system_arm only: 'disarmed'|'away'|'night'|'day'|'vacation'
  * @property {number|null} [report] - status_request only
- * @property {string|null} [detail] - arm_failed/fire_alarm free-text argument
+ * @property {string|null} [detail] - detail-suffixed trouble verbs' free-text argument
+ * @property {string} [condition] - panel_trouble only: 'mains'|'battery'|'tamper'|'panic'|'line'|'arm_failed'|'fire'
+ * @property {boolean} [active] - panel_trouble only: true = raised, false = cleared
  */
 
 /**
@@ -246,14 +263,14 @@ class SecurityEventHandler {
                 return 'Exit delay started';
             case 'zone_isolated':
                 return `Zone ${reading.zone} bypassed`;
-            case 'arm_failed':
-                return reading.detail ? `Arm failed (${reading.detail})` : 'Arm failed';
             case 'alarm_on':
                 return 'Alarm on';
             case 'alarm_off':
                 return 'Alarm off';
-            case 'fire_alarm':
-                return reading.detail ? `Fire alarm (${reading.detail})` : 'Fire alarm';
+            case 'panel_trouble':
+                return PANEL_TROUBLE_TEXT[reading.condition]
+                    ? PANEL_TROUBLE_TEXT[reading.condition][reading.active ? 'raised' : 'cleared']
+                    : reading.condition;
             default:
                 return reading.kind;
         }

--- a/src/securityEventHandler.js
+++ b/src/securityEventHandler.js
@@ -5,20 +5,20 @@ const securityDecoder = require('./applicationDecoders/securityDecoder');
 const SecurityPanelState = require('./securityPanelState');
 const { buildSecurityStatusRequest } = require('./securityCommand');
 const { NEWLINE } = require('./constants');
+const { describePanelCondition } = require('./securityPanelConditions');
 
 /**
- * User-facing wording for each panel trouble condition, in both senses. The
- * panel's own `_raised`/`_cleared` argument is deliberately not echoed into the
- * log line: the sense is already carried by the wording.
+ * Which dedupe slot each status-sync trigger consumes. 'resync' has no slot: a
+ * Home Assistant or broker restart can happen any number of times in one bridge
+ * session and each one genuinely needs the zone state resent, so it is exempt
+ * from the once-per-session dedupe. Rate limiting for that trigger is the resync
+ * coordinator's debounce instead.
  */
-const PANEL_TROUBLE_TEXT = {
-    mains: { raised: 'Mains power failure', cleared: 'Mains power restored' },
-    battery: { raised: 'Battery low', cleared: 'Battery restored' },
-    tamper: { raised: 'Tamper detected', cleared: 'Tamper cleared' },
-    panic: { raised: 'Panic activated', cleared: 'Panic cleared' },
-    line: { raised: 'Phone line cut', cleared: 'Phone line restored' },
-    arm_failed: { raised: 'Arm failed', cleared: 'Arm failure cleared' },
-    fire: { raised: 'Fire alarm', cleared: 'Fire alarm cleared' }
+const SYNC_TRIGGER_SLOTS = {
+    connect: 'early',
+    traffic: 'early',
+    sync: 'postSync',
+    resync: null
 };
 
 /**
@@ -126,23 +126,24 @@ class SecurityEventHandler {
         if (!this.sendCommand || !this.cbusname) return false;
         if (network === null || network === undefined) return false;
 
+        if (!Object.prototype.hasOwnProperty.call(SYNC_TRIGGER_SLOTS, trigger)) {
+            // Fail loudly rather than consuming a dedupe slot: silently burning
+            // the 'early' slot on a typo would suppress the real connect/traffic
+            // sync for the rest of the session.
+            this.logger.warn(`Unknown security status-sync trigger '${trigger}'; ignoring`);
+            return false;
+        }
+
         const key = `${network}/${appId}`;
         let state = this._syncState.get(key);
         if (!state) {
             state = { early: false, postSync: false };
             this._syncState.set(key, state);
         }
-        if (trigger === 'resync') {
-            // Home Assistant or broker restart (issue #44). Deliberately exempt
-            // from the once-per-session dedupe: HA can restart any number of
-            // times in a session, and each restart genuinely needs the zone
-            // state resent. Rate limiting is the resync coordinator's debounce.
-        } else if (trigger === 'sync') {
-            if (state.postSync) return false;
-            state.postSync = true;
-        } else {
-            if (state.early) return false;
-            state.early = true;
+        const slot = SYNC_TRIGGER_SLOTS[trigger];
+        if (slot) {
+            if (state[slot]) return false;
+            state[slot] = true;
         }
 
         for (const report of [1, 2]) {
@@ -181,10 +182,12 @@ class SecurityEventHandler {
                 for (const entry of reading.zones) {
                     this._publishZone(reading.network, reading.application, String(entry.zone), entry.state);
                 }
-                // Report 1's prefix bytes are the only authoritative source for
-                // tamper and panic, so let them correct the assumed-healthy seed.
-                this._publishPanelChanges(reading.network, reading.application,
-                    this.panelState.seedFromStatusReport(reading));
+                // Only report 1 carries the tamper and panic prefix bytes, which
+                // are the one authoritative source for those two conditions.
+                if (reading.kind === 'status_report_1') {
+                    this._publishPanelChanges(reading.network, reading.application,
+                        this.panelState.seedFromStatusReport(reading));
+                }
                 this._logStatusReportSummary(reading);
             } else if (reading.kind === 'panel_trouble') {
                 this._publishPanelChanges(reading.network, reading.application,
@@ -261,16 +264,12 @@ class SecurityEventHandler {
      */
     _publishPanelChanges(network, application, changes) {
         const haDiscovery = this.getHaDiscovery();
-        if (haDiscovery && typeof haDiscovery.ensureSecurityPanelDiscovery === 'function') {
-            if (haDiscovery.ensureSecurityPanelDiscovery(network, application)) {
-                // Newly announced: seed every condition so none sits Unknown.
-                for (const { condition, active } of this.panelState.initialStates(network)) {
-                    this._publishPanelCondition(network, application, condition, active);
-                }
-                return;
-            }
-        }
-        for (const { condition, active } of changes) {
+        const justAnnounced = haDiscovery && haDiscovery.ensureSecurityPanelDiscovery(network, application);
+        // On the first announce, publish all seven so none sits Unknown in HA.
+        // Callers always fold their reading into the tracker before calling, so
+        // the seed is a superset of `changes` rather than a competing view.
+        const toPublish = justAnnounced ? this.panelState.initialStates(network) : changes;
+        for (const { condition, active } of toPublish) {
             this._publishPanelCondition(network, application, condition, active);
         }
     }
@@ -334,9 +333,7 @@ class SecurityEventHandler {
             case 'alarm_off':
                 return 'Alarm off';
             case 'panel_trouble':
-                return PANEL_TROUBLE_TEXT[reading.condition]
-                    ? PANEL_TROUBLE_TEXT[reading.condition][reading.active ? 'raised' : 'cleared']
-                    : reading.condition;
+                return describePanelCondition(reading.condition, reading.active === true);
             default:
                 return reading.kind;
         }

--- a/src/securityEventHandler.js
+++ b/src/securityEventHandler.js
@@ -117,7 +117,7 @@ class SecurityEventHandler {
      * 'sync' has its own slot, so a post-sync refresh is always allowed once.
      *
      * @param {string|number} network - C-Bus network id.
-     * @param {'connect'|'traffic'|'sync'} trigger - What prompted the request.
+     * @param {'connect'|'traffic'|'sync'|'resync'} trigger - What prompted the request.
      * @returns {boolean} true when the request pair was actually sent.
      */
     requestStatusSync(network, trigger) {
@@ -132,7 +132,12 @@ class SecurityEventHandler {
             state = { early: false, postSync: false };
             this._syncState.set(key, state);
         }
-        if (trigger === 'sync') {
+        if (trigger === 'resync') {
+            // Home Assistant or broker restart (issue #44). Deliberately exempt
+            // from the once-per-session dedupe: HA can restart any number of
+            // times in a session, and each restart genuinely needs the zone
+            // state resent. Rate limiting is the resync coordinator's debounce.
+        } else if (trigger === 'sync') {
             if (state.postSync) return false;
             state.postSync = true;
         } else {

--- a/src/securityEventHandler.js
+++ b/src/securityEventHandler.js
@@ -150,7 +150,8 @@ class SecurityEventHandler {
                 this._emitEventLog(reading.network, reading.application, reading.zone,
                     reading.zoneState === 'sealed' ? 0 : 255,
                     reading.zoneState === 'sealed' ? 'off' : 'on',
-                    this._zoneLabel(reading.network, reading.zone));
+                    this._zoneLabel(reading.network, reading.zone),
+                    `Zone ${reading.zoneState}`);
             } else if (reading.kind === 'status_report_1' || reading.kind === 'status_report_2') {
                 for (const entry of reading.zones) {
                     this._publishZone(reading.network, reading.application, String(entry.zone), entry.state);
@@ -261,8 +262,11 @@ class SecurityEventHandler {
     /**
      * Surface a system-state reading in the Live Events stream. Uses the zone
      * as the group when the verb carries one (arm_not_ready, zone_isolated),
-     * otherwise '0' (panel-wide event). Level/type follow the on/off-ish
-     * verbs so the UI bar and styling match other events.
+     * otherwise null — the UI renders a group-less entry as net/app instead of
+     * inventing a net/app/0 address that matches no real C-Bus object.
+     * Level/type follow the on/off-ish verbs so the UI styling matches other
+     * events; the description carries the human-readable text so the UI never
+     * has to render a meaningless level percentage for a security event.
      *
      * @param {SecurityReading} reading
      * @private
@@ -276,8 +280,9 @@ class SecurityEventHandler {
         } else if (reading.kind === 'alarm_off' || (reading.kind === 'system_arm' && reading.mode === 0)) {
             type = 'off';
         }
-        this._emitEventLog(reading.network, reading.application, reading.zone || '0', level, type,
-            reading.zone ? this._zoneLabel(reading.network, reading.zone) : null);
+        this._emitEventLog(reading.network, reading.application, reading.zone || null, level, type,
+            reading.zone ? this._zoneLabel(reading.network, reading.zone) : null,
+            this._describeSystemEvent(reading));
     }
 
     /**
@@ -301,13 +306,20 @@ class SecurityEventHandler {
     /**
      * Emit one Live Events (SSE) entry in the same shape EventPublisher uses
      * for lighting events ({ ts, network, app, group, level, type }), plus an
-     * optional display label the UI prefers over its own label lookup.
+     * optional display label the UI prefers over its own label lookup and an
+     * optional human-readable description. When a description is present the UI
+     * shows it in place of the level percentage, because "0 (0%)" says nothing
+     * useful about a zone unsealing or a system arming (issue #42 feedback).
      *
      * @private
      */
-    _emitEventLog(network, application, group, level, type, label = null) {
+    _emitEventLog(network, application, group, level, type, label = null, description = null) {
         if (!this.onEventLog) return;
-        this.onEventLog({ ts: Date.now(), network, app: application, group, level, type, ...(label && { label }) });
+        this.onEventLog({
+            ts: Date.now(), network, app: application, group, level, type,
+            ...(label && { label }),
+            ...(description && { description })
+        });
     }
 }
 

--- a/src/securityEventHandler.js
+++ b/src/securityEventHandler.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const securityDecoder = require('./applicationDecoders/securityDecoder');
+const SecurityPanelState = require('./securityPanelState');
 const { buildSecurityStatusRequest } = require('./securityCommand');
 const { NEWLINE } = require('./constants');
 
@@ -83,6 +84,8 @@ class SecurityEventHandler {
         // e.g. a bridge restart on an already-synced network); 'postSync'
         // covers the 762 sync-ok trigger. At most one pair each per session.
         this._syncState = new Map();
+        // Panel-wide trouble conditions, so repeated verbs don't republish.
+        this.panelState = new SecurityPanelState();
     }
 
     /**
@@ -173,13 +176,31 @@ class SecurityEventHandler {
                 for (const entry of reading.zones) {
                     this._publishZone(reading.network, reading.application, String(entry.zone), entry.state);
                 }
+                // Report 1's prefix bytes are the only authoritative source for
+                // tamper and panic, so let them correct the assumed-healthy seed.
+                this._publishPanelChanges(reading.network, reading.application,
+                    this.panelState.seedFromStatusReport(reading));
                 this._logStatusReportSummary(reading);
+            } else if (reading.kind === 'panel_trouble') {
+                this._publishPanelChanges(reading.network, reading.application,
+                    this.panelState.applyReading(reading));
+                this.logger.info(
+                    `C-Bus Security: ${this._describeSystemEvent(reading)} (${reading.network}/${reading.application})`
+                );
+                this._emitSystemEventLog(reading);
             } else if (reading.kind === 'status_request') {
                 // Echo of our own request on the event port — consume quietly.
                 if (this.logger.isLevelEnabled && this.logger.isLevelEnabled('debug')) {
                     this.logger.debug(`Security status_request echo (${reading.network}/${reading.application}, report ${reading.report})`);
                 }
             } else {
+                // A disarm clears panic, arm failure and fire even though the
+                // panel sends no dedicated cleared verb for them, and a
+                // successful arm retires an earlier arm failure.
+                if (reading.kind === 'system_arm') {
+                    this._publishPanelChanges(reading.network, reading.application,
+                        this.panelState.applyReading(reading));
+                }
                 // System-state verbs (arm_ready, system_arm, alarm_on/off, …):
                 // phase 2 material — no MQTT state, but log them human-readably
                 // and surface them in the Live Events stream.
@@ -220,6 +241,46 @@ class SecurityEventHandler {
         if (haDiscovery) {
             haDiscovery.ensureSecurityZoneDiscovery(network, application, zone);
         }
+    }
+
+    /**
+     * Publish changed panel trouble conditions and make sure the panel's
+     * entities exist. Discovery runs even when nothing changed, so a healthy
+     * panel still gets its seven sensors seeded to OFF on first traffic rather
+     * than waiting for its first fault.
+     *
+     * @param {string} network
+     * @param {string} application
+     * @param {Array<{condition: string, active: boolean}>} changes
+     * @private
+     */
+    _publishPanelChanges(network, application, changes) {
+        const haDiscovery = this.getHaDiscovery();
+        if (haDiscovery && typeof haDiscovery.ensureSecurityPanelDiscovery === 'function') {
+            if (haDiscovery.ensureSecurityPanelDiscovery(network, application)) {
+                // Newly announced: seed every condition so none sits Unknown.
+                for (const { condition, active } of this.panelState.initialStates(network)) {
+                    this._publishPanelCondition(network, application, condition, active);
+                }
+                return;
+            }
+        }
+        for (const { condition, active } of changes) {
+            this._publishPanelCondition(network, application, condition, active);
+        }
+    }
+
+    /**
+     * @param {string} network
+     * @param {string} application
+     * @param {string} condition
+     * @param {boolean} active
+     * @private
+     */
+    _publishPanelCondition(network, application, condition, active) {
+        this.eventPublisher.publishReading(network, application, `panel/${condition}`, {
+            kind: 'security_panel', active
+        });
     }
 
     /**

--- a/src/securityPanelConditions.js
+++ b/src/securityPanelConditions.js
@@ -1,0 +1,165 @@
+// @ts-check
+'use strict';
+
+/**
+ * The C-Bus Security panel's own health conditions, as opposed to its zones.
+ *
+ * Single source of truth for everything one condition needs: the verbs that
+ * raise and clear it on the wire, its Home Assistant entity name and device
+ * class, the wording used in logs and the Live Events feed, and whether the
+ * panel clears it implicitly rather than sending a dedicated verb. Adding an
+ * eighth condition is one record here; previously the same knowledge was spread
+ * across four modules where forgetting one left a silent hole (an entity named
+ * `undefined`, or a log line showing the raw condition id).
+ *
+ * Verb pairs are confirmed by the 2026-07-29 captures on a 64-zone Cytech panel
+ * (GitHub issue #42) except `low_battery`, `tamper_on` and `panic_off`, whose
+ * halves were never captured — the panel only ever emitted
+ * `low_battery_corrected`, `tamper_off` and `panic_activated`. Those three names
+ * are inferred from the convention of the confirmed pairs. Handling a verb that
+ * never arrives costs nothing, and `panic` recovers via `clearedOnDisarm`
+ * regardless of whether `panic_off` exists.
+ *
+ * `detailSensed` marks the three verbs that carry their sense in a
+ * `<verb>_raised` / `<verb>_cleared` argument rather than in the verb name; a
+ * bare verb with no argument means raised.
+ *
+ * `clearedOnDisarm` covers conditions the panel never explicitly clears: the
+ * tester confirmed disarming "clears all possible trouble conditions", and both
+ * the arm-failure and fire captures end alarm_on → alarm_off → system_arm 0 with
+ * no cleared verb in between. Mains, battery, tamper and line are deliberately
+ * excluded — disarming cannot restore mains power or reconnect a cut phone
+ * line, and the panel does send real restored/corrected verbs for those.
+ *
+ * Order is display order (HA sorts diagnostics by name, but the discovery
+ * publish order and status logs follow this).
+ */
+const PANEL_CONDITIONS = [
+    {
+        id: 'mains',
+        raiseVerb: 'mains_failure',
+        clearVerb: 'mains_restored',
+        name: 'Mains power',
+        deviceClass: 'problem',
+        raisedText: 'Mains power failure',
+        clearedText: 'Mains power restored'
+    },
+    {
+        id: 'battery',
+        raiseVerb: 'low_battery',
+        clearVerb: 'low_battery_corrected',
+        name: 'Battery',
+        deviceClass: 'battery',
+        raisedText: 'Battery low',
+        clearedText: 'Battery restored'
+    },
+    {
+        id: 'tamper',
+        raiseVerb: 'tamper_on',
+        clearVerb: 'tamper_off',
+        name: 'Tamper',
+        deviceClass: 'tamper',
+        raisedText: 'Tamper detected',
+        clearedText: 'Tamper cleared'
+    },
+    {
+        id: 'panic',
+        raiseVerb: 'panic_activated',
+        // Two spellings accepted: neither was captured, so both plausible
+        // inferences are handled rather than betting on one.
+        clearVerb: ['panic_off', 'panic_cleared'],
+        clearedOnDisarm: true,
+        name: 'Panic',
+        deviceClass: 'safety',
+        raisedText: 'Panic activated',
+        clearedText: 'Panic cleared'
+    },
+    {
+        id: 'line',
+        detailVerb: 'line_cut_alarm',
+        name: 'Phone line',
+        deviceClass: 'problem',
+        raisedText: 'Phone line cut',
+        clearedText: 'Phone line restored'
+    },
+    {
+        id: 'arm_failed',
+        detailVerb: 'arm_failed',
+        clearedOnDisarm: true,
+        // A successful arm retires an earlier failure to arm.
+        clearedOnArm: true,
+        name: 'Arm failed',
+        deviceClass: 'problem',
+        raisedText: 'Arm failed',
+        clearedText: 'Arm failure cleared'
+    },
+    {
+        id: 'fire',
+        detailVerb: 'fire_alarm',
+        clearedOnDisarm: true,
+        name: 'Fire alarm',
+        deviceClass: 'smoke',
+        raisedText: 'Fire alarm',
+        clearedText: 'Fire alarm cleared'
+    }
+];
+
+/** Condition ids in display order. */
+const PANEL_TROUBLE_CONDITIONS = PANEL_CONDITIONS.map((c) => c.id);
+
+/** Condition id → record. */
+const PANEL_CONDITION_BY_ID = new Map(PANEL_CONDITIONS.map((c) => [c.id, c]));
+
+/**
+ * Verb → { condition, active } for verbs that name their own sense.
+ * @type {Map<string, { condition: string, active: boolean }>}
+ */
+const PANEL_TROUBLE_VERBS = new Map();
+/**
+ * Verb → condition id for verbs whose sense rides a _raised/_cleared argument.
+ * @type {Map<string, string>}
+ */
+const PANEL_TROUBLE_DETAIL_VERBS = new Map();
+
+for (const condition of PANEL_CONDITIONS) {
+    if (condition.raiseVerb) {
+        PANEL_TROUBLE_VERBS.set(condition.raiseVerb, { condition: condition.id, active: true });
+    }
+    for (const verb of [].concat(condition.clearVerb || [])) {
+        PANEL_TROUBLE_VERBS.set(verb, { condition: condition.id, active: false });
+    }
+    if (condition.detailVerb) {
+        PANEL_TROUBLE_DETAIL_VERBS.set(condition.detailVerb, condition.id);
+    }
+}
+
+/** Conditions the panel clears implicitly on disarm (system_arm mode 0). */
+const CLEARED_ON_DISARM = PANEL_CONDITIONS.filter((c) => c.clearedOnDisarm).map((c) => c.id);
+
+/** Conditions retired by a successful arm (system_arm with a non-zero mode). */
+const CLEARED_ON_ARM = PANEL_CONDITIONS.filter((c) => c.clearedOnArm).map((c) => c.id);
+
+/**
+ * Human-readable wording for a condition in the given sense. Falls back to the
+ * raw id so an unmapped condition is still legible.
+ *
+ * @param {string} conditionId
+ * @param {boolean} active
+ * @returns {string}
+ */
+function describePanelCondition(conditionId, active) {
+    const condition = PANEL_CONDITION_BY_ID.get(conditionId);
+    if (!condition) return conditionId;
+    return active ? condition.raisedText : condition.clearedText;
+}
+
+module.exports = {
+    PANEL_CONDITIONS,
+    PANEL_CONDITION_BY_ID,
+    PANEL_TROUBLE_CONDITIONS,
+    PANEL_TROUBLE_VERBS,
+    PANEL_TROUBLE_DETAIL_VERBS,
+    CLEARED_ON_DISARM,
+    CLEARED_ON_ARM,
+    describePanelCondition
+};

--- a/src/securityPanelState.js
+++ b/src/securityPanelState.js
@@ -1,25 +1,11 @@
 // @ts-check
 'use strict';
 
-const { PANEL_TROUBLE_CONDITIONS } = require('./applicationDecoders/securityDecoder');
-
-/**
- * Conditions the panel clears implicitly on disarm. The 2026-07-29 captures in
- * issue #42 never show an explicit clear for panic or fire, and the tester
- * confirmed that disarming "clears all possible trouble conditions" - both the
- * arm-failure and fire-alarm sequences end alarm_on → alarm_off → system_arm 0
- * with no dedicated cleared verb in between.
- *
- * Mains, battery, tamper and line are deliberately absent: a power fault or a
- * cut phone line is a physical condition that disarming the panel cannot fix,
- * and the panel does emit explicit restored/corrected verbs for those.
- */
-const CLEARED_ON_DISARM = ['panic', 'arm_failed', 'fire'];
-
-/**
- * Cleared by a *successful* arm, since the previous failure is now moot.
- */
-const CLEARED_ON_ARM = ['arm_failed'];
+const {
+    PANEL_TROUBLE_CONDITIONS,
+    CLEARED_ON_DISARM,
+    CLEARED_ON_ARM
+} = require('./securityPanelConditions');
 
 /**
  * Tracks panel-wide trouble state per C-Bus network so the bridge only
@@ -100,17 +86,6 @@ class SecurityPanelState {
     initialStates(network) {
         const state = this._forNetwork(network);
         return PANEL_TROUBLE_CONDITIONS.map((condition) => ({ condition, active: state[condition] }));
-    }
-
-    /**
-     * Snapshot of one network's conditions. Returns a copy - callers must not
-     * be able to mutate the tracker's state by editing the result.
-     *
-     * @param {string} network
-     * @returns {Object<string, boolean>}
-     */
-    getState(network) {
-        return { ...this._forNetwork(network) };
     }
 
     /**

--- a/src/securityPanelState.js
+++ b/src/securityPanelState.js
@@ -1,0 +1,149 @@
+// @ts-check
+'use strict';
+
+const { PANEL_TROUBLE_CONDITIONS } = require('./applicationDecoders/securityDecoder');
+
+/**
+ * Conditions the panel clears implicitly on disarm. The 2026-07-29 captures in
+ * issue #42 never show an explicit clear for panic or fire, and the tester
+ * confirmed that disarming "clears all possible trouble conditions" - both the
+ * arm-failure and fire-alarm sequences end alarm_on → alarm_off → system_arm 0
+ * with no dedicated cleared verb in between.
+ *
+ * Mains, battery, tamper and line are deliberately absent: a power fault or a
+ * cut phone line is a physical condition that disarming the panel cannot fix,
+ * and the panel does emit explicit restored/corrected verbs for those.
+ */
+const CLEARED_ON_DISARM = ['panic', 'arm_failed', 'fire'];
+
+/**
+ * Cleared by a *successful* arm, since the previous failure is now moot.
+ */
+const CLEARED_ON_ARM = ['arm_failed'];
+
+/**
+ * Tracks panel-wide trouble state per C-Bus network so the bridge only
+ * publishes actual transitions. A panel repeating `mains_failure` while the
+ * power is still out should not republish MQTT state or re-log at INFO.
+ *
+ * Deliberately separate from SecurityEventHandler: the transition and
+ * derived-clear rules are the fiddly part of this feature and are far easier to
+ * test as a standalone unit than through the handler's line-parsing path.
+ */
+class SecurityPanelState {
+    constructor() {
+        /** @type {Map<string, Object<string, boolean>>} network → condition → active */
+        this._byNetwork = new Map();
+    }
+
+    /**
+     * Apply a decoded reading and report which conditions actually changed.
+     *
+     * Handles both explicit `panel_trouble` readings and the derived clears
+     * that ride `system_arm`, so callers can pass every reading through without
+     * knowing which verbs imply what.
+     *
+     * @param {{kind: string, network: string, condition?: string, active?: boolean, mode?: number|null}} reading
+     * @returns {Array<{condition: string, active: boolean}>} changed conditions only
+     */
+    applyReading(reading) {
+        if (!reading || reading.network === null || reading.network === undefined) return [];
+
+        if (reading.kind === 'panel_trouble') {
+            if (!reading.condition || !PANEL_TROUBLE_CONDITIONS.includes(reading.condition)) return [];
+            return this._set(reading.network, reading.condition, reading.active === true);
+        }
+
+        if (reading.kind === 'system_arm') {
+            const conditions = reading.mode === 0 ? CLEARED_ON_DISARM : CLEARED_ON_ARM;
+            const changed = [];
+            for (const condition of conditions) {
+                changed.push(...this._set(reading.network, condition, false));
+            }
+            return changed;
+        }
+
+        return [];
+    }
+
+    /**
+     * Seed tamper and panic from a status_report_1, whose prefix bytes are the
+     * only authoritative source we have for those two conditions. The other
+     * five are event-driven only - the panel offers no way to query them.
+     *
+     * @param {{kind: string, network: string, tamperActive?: boolean, panicActive?: boolean}} reading
+     * @returns {Array<{condition: string, active: boolean}>} changed conditions only
+     */
+    seedFromStatusReport(reading) {
+        if (!reading || reading.network === null || reading.network === undefined) return [];
+        const changed = [];
+        if (typeof reading.tamperActive === 'boolean') {
+            changed.push(...this._set(reading.network, 'tamper', reading.tamperActive));
+        }
+        if (typeof reading.panicActive === 'boolean') {
+            changed.push(...this._set(reading.network, 'panic', reading.panicActive));
+        }
+        return changed;
+    }
+
+    /**
+     * All seven conditions and their current values, for seeding state at
+     * discovery time. Conditions never seen default to inactive: assuming
+     * healthy keeps the entities usable in automations immediately, and a stale
+     * value self-corrects on the next transition or disarm. The alternative
+     * leaves them Unknown indefinitely on a healthy panel, which is the
+     * complaint behind issue #44.
+     *
+     * @param {string} network
+     * @returns {Array<{condition: string, active: boolean}>} all seven
+     */
+    initialStates(network) {
+        const state = this._forNetwork(network);
+        return PANEL_TROUBLE_CONDITIONS.map((condition) => ({ condition, active: state[condition] }));
+    }
+
+    /**
+     * Snapshot of one network's conditions. Returns a copy - callers must not
+     * be able to mutate the tracker's state by editing the result.
+     *
+     * @param {string} network
+     * @returns {Object<string, boolean>}
+     */
+    getState(network) {
+        return { ...this._forNetwork(network) };
+    }
+
+    /**
+     * @param {string} network
+     * @returns {Object<string, boolean>}
+     * @private
+     */
+    _forNetwork(network) {
+        const key = String(network);
+        let state = this._byNetwork.get(key);
+        if (!state) {
+            state = {};
+            for (const condition of PANEL_TROUBLE_CONDITIONS) state[condition] = false;
+            this._byNetwork.set(key, state);
+        }
+        return state;
+    }
+
+    /**
+     * Set one condition, returning it only if the value actually changed.
+     *
+     * @param {string} network
+     * @param {string} condition
+     * @param {boolean} active
+     * @returns {Array<{condition: string, active: boolean}>}
+     * @private
+     */
+    _set(network, condition, active) {
+        const state = this._forNetwork(network);
+        if (state[condition] === active) return [];
+        state[condition] = active;
+        return [{ condition, active }];
+    }
+}
+
+module.exports = SecurityPanelState;

--- a/src/stateResyncCoordinator.js
+++ b/src/stateResyncCoordinator.js
@@ -1,7 +1,13 @@
 // @ts-check
 'use strict';
 
-const { CGATE_CMD_GET, CGATE_PARAM_LEVEL, NEWLINE } = require('./constants');
+/**
+ * Triggers that also need the retained HA Discovery configs replayed, not just
+ * state. A broker restart without persistence drops the configs, so the entities
+ * are gone rather than merely stale; a Home Assistant restart leaves the broker
+ * untouched, so its retained configs are still there to be re-read.
+ */
+const TRIGGERS_NEEDING_DISCOVERY_REPUBLISH = new Set(['mqtt-reconnect']);
 
 /**
  * Republishes entity state after Home Assistant or the MQTT broker restarts
@@ -26,27 +32,22 @@ class StateResyncCoordinator {
     /**
      * @param {Object} deps
      * @param {Object} deps.settings
-     * @param {{ add: (cmd: string) => void }} deps.commandQueue
      * @param {ReturnType<typeof import('./logger').createLogger>} deps.logger
      * @param {() => (Object|null)} deps.getHaDiscovery - late-bound: haDiscovery is built after the bridge constructor
-     * @param {() => (Object|null)} deps.getSecurityEventHandler
-     * @param {{ _resolveGetallNetworks: () => string[] }} deps.initializationService
+     * @param {{ sendGetallLevels: Function, sendSecurityStatusRequests: Function }} deps.initializationService
      */
-    constructor({ settings, commandQueue, logger, getHaDiscovery, getSecurityEventHandler, initializationService }) {
+    constructor({ settings, logger, getHaDiscovery, initializationService }) {
         this.settings = settings;
-        this.commandQueue = commandQueue;
         this.logger = logger;
         this.getHaDiscovery = getHaDiscovery;
-        this.getSecurityEventHandler = getSecurityEventHandler;
         this.initializationService = initializationService;
 
         /** @type {NodeJS.Timeout|null} */
         this._pending = null;
-        /** @type {Set<string>} triggers collapsed into the pending resync */
+        // Triggers collapsed into the pending resync. Also the sticky record of
+        // whether any of them needed the discovery configs replayed.
+        /** @type {Set<string>} */
         this._pendingTriggers = new Set();
-        // Sticky across collapsed triggers: if any of them wanted the configs
-        // republished, the single resync that runs must do it.
-        this._pendingRepublishDiscovery = false;
     }
 
     /**
@@ -54,17 +55,15 @@ class StateResyncCoordinator {
      * one.
      *
      * @param {'ha-birth'|'mqtt-reconnect'|string} trigger
-     * @param {{ republishDiscovery?: boolean }} [options]
      * @returns {boolean} true when a resync is now pending
      */
-    requestResync(trigger, options = {}) {
+    requestResync(trigger) {
         if (!this._triggerEnabled(trigger)) {
             this.logger.debug(`State resync trigger '${trigger}' is disabled by settings`);
             return false;
         }
 
         this._pendingTriggers.add(trigger);
-        if (options.republishDiscovery) this._pendingRepublishDiscovery = true;
 
         if (this._pending) clearTimeout(this._pending);
         const debounceMs = Number(this.settings.stateResyncDebounceMs) || 5000;
@@ -82,7 +81,6 @@ class StateResyncCoordinator {
             this._pending = null;
         }
         this._pendingTriggers.clear();
-        this._pendingRepublishDiscovery = false;
     }
 
     /**
@@ -101,20 +99,31 @@ class StateResyncCoordinator {
      */
     _runResync() {
         this._pending = null;
-        const triggers = [...this._pendingTriggers].join(', ');
-        const republishDiscovery = this._pendingRepublishDiscovery;
+        const pendingTriggers = [...this._pendingTriggers];
+        const triggers = pendingTriggers.join(', ');
+        const republishDiscovery = pendingTriggers.some((t) => TRIGGERS_NEEDING_DISCOVERY_REPUBLISH.has(t));
         this._pendingTriggers.clear();
-        this._pendingRepublishDiscovery = false;
 
         let configs = 0;
         if (republishDiscovery) {
             const haDiscovery = this.getHaDiscovery();
-            if (haDiscovery && typeof haDiscovery.republishDiscoveryConfigs === 'function') {
-                configs = haDiscovery.republishDiscoveryConfigs();
-            }
+            if (haDiscovery) configs = haDiscovery.republishDiscoveryConfigs();
         }
 
-        const netapps = this.initializationService._resolveGetallNetworks();
+        // 'bulk' priority: a resync can be dozens of commands, and it fires
+        // exactly when someone is likely pressing switches (they just restarted
+        // HA). Startup's getall gets away with normal priority because nothing
+        // competes with it; here a user command must not queue behind the flood.
+        const netapps = this.initializationService.sendGetallLevels(null, { priority: 'bulk' });
+
+        // Security panels do not answer lighting-style getall (spec §5.9), so the
+        // zone sensors need their own status_request pair or they would go stale
+        // across exactly the restart this coordinator exists to fix. This is
+        // resolved from ha_discovery_networks, not from the getall pairs: the
+        // security app is deliberately absent from those, so an install with
+        // ha_discovery_networks set but no getall_networks still resyncs zones.
+        this.initializationService.sendSecurityStatusRequests('resync');
+
         if (netapps.length === 0) {
             this.logger.debug(
                 `State resync (${triggers}) had no getall networks configured, so no levels were requested`
@@ -122,26 +131,8 @@ class StateResyncCoordinator {
             return;
         }
 
-        for (const netapp of netapps) {
-            this.commandQueue.add(
-                `${CGATE_CMD_GET} //${this.settings.cbusname}/${netapp}/* ${CGATE_PARAM_LEVEL}${NEWLINE}`
-            );
-        }
-
-        // Security panels do not answer lighting-style getall (spec §5.9), so
-        // the zone sensors need their own status_request pair or they would stay
-        // stale across exactly the restart this coordinator exists to fix.
-        const securityEventHandler = this.getSecurityEventHandler();
-        const networks = new Set(netapps.map((netapp) => String(netapp).split('/')[0]));
-        if (securityEventHandler && typeof securityEventHandler.requestStatusSync === 'function') {
-            for (const network of networks) {
-                securityEventHandler.requestStatusSync(network, 'resync');
-            }
-        }
-
         this.logger.info(
-            `State resync (${triggers}): requested levels for ${netapps.length} network/app pair(s), ` +
-            `${networks.size} security status sync(s)` +
+            `State resync (${triggers}): requested levels for ${netapps.length} network/app pair(s)` +
             (republishDiscovery ? `, republished ${configs} discovery config(s)` : '')
         );
     }

--- a/src/stateResyncCoordinator.js
+++ b/src/stateResyncCoordinator.js
@@ -1,0 +1,150 @@
+// @ts-check
+'use strict';
+
+const { CGATE_CMD_GET, CGATE_PARAM_LEVEL, NEWLINE } = require('./constants');
+
+/**
+ * Republishes entity state after Home Assistant or the MQTT broker restarts
+ * (issue #44).
+ *
+ * Neither restart is visible as a bridge restart, so nothing would otherwise
+ * refresh Home Assistant:
+ *
+ *  - HA restarting does not restart the add-on and does not drop the bridge's
+ *    own broker connection. With retainreads off (the default) HA comes back
+ *    with no retained state to read, so entities sit unknown until the next
+ *    physical C-Bus event — the "two lightning bolts that snap to a real icon
+ *    on first use" in the issue.
+ *  - The broker restarting drops the retained discovery configs too if it has
+ *    no persistence, so the entities disappear entirely rather than merely
+ *    losing state.
+ *
+ * Both triggers route through one debounce so a broker bounce that also
+ * restarts HA resyncs once rather than twice.
+ */
+class StateResyncCoordinator {
+    /**
+     * @param {Object} deps
+     * @param {Object} deps.settings
+     * @param {{ add: (cmd: string) => void }} deps.commandQueue
+     * @param {ReturnType<typeof import('./logger').createLogger>} deps.logger
+     * @param {() => (Object|null)} deps.getHaDiscovery - late-bound: haDiscovery is built after the bridge constructor
+     * @param {() => (Object|null)} deps.getSecurityEventHandler
+     * @param {{ _resolveGetallNetworks: () => string[] }} deps.initializationService
+     */
+    constructor({ settings, commandQueue, logger, getHaDiscovery, getSecurityEventHandler, initializationService }) {
+        this.settings = settings;
+        this.commandQueue = commandQueue;
+        this.logger = logger;
+        this.getHaDiscovery = getHaDiscovery;
+        this.getSecurityEventHandler = getSecurityEventHandler;
+        this.initializationService = initializationService;
+
+        /** @type {NodeJS.Timeout|null} */
+        this._pending = null;
+        /** @type {Set<string>} triggers collapsed into the pending resync */
+        this._pendingTriggers = new Set();
+        // Sticky across collapsed triggers: if any of them wanted the configs
+        // republished, the single resync that runs must do it.
+        this._pendingRepublishDiscovery = false;
+    }
+
+    /**
+     * Request a resync. Repeated calls inside the debounce window collapse into
+     * one.
+     *
+     * @param {'ha-birth'|'mqtt-reconnect'|string} trigger
+     * @param {{ republishDiscovery?: boolean }} [options]
+     * @returns {boolean} true when a resync is now pending
+     */
+    requestResync(trigger, options = {}) {
+        if (!this._triggerEnabled(trigger)) {
+            this.logger.debug(`State resync trigger '${trigger}' is disabled by settings`);
+            return false;
+        }
+
+        this._pendingTriggers.add(trigger);
+        if (options.republishDiscovery) this._pendingRepublishDiscovery = true;
+
+        if (this._pending) clearTimeout(this._pending);
+        const debounceMs = Number(this.settings.stateResyncDebounceMs) || 5000;
+        this._pending = setTimeout(() => this._runResync(), debounceMs);
+        if (typeof this._pending.unref === 'function') this._pending.unref();
+        return true;
+    }
+
+    /**
+     * Cancel any pending resync (bridge shutdown).
+     */
+    dispose() {
+        if (this._pending) {
+            clearTimeout(this._pending);
+            this._pending = null;
+        }
+        this._pendingTriggers.clear();
+        this._pendingRepublishDiscovery = false;
+    }
+
+    /**
+     * @param {string} trigger
+     * @returns {boolean}
+     * @private
+     */
+    _triggerEnabled(trigger) {
+        if (trigger === 'ha-birth') return this.settings.stateResyncOnHaRestart !== false;
+        if (trigger === 'mqtt-reconnect') return this.settings.stateResyncOnMqttReconnect !== false;
+        return true;
+    }
+
+    /**
+     * @private
+     */
+    _runResync() {
+        this._pending = null;
+        const triggers = [...this._pendingTriggers].join(', ');
+        const republishDiscovery = this._pendingRepublishDiscovery;
+        this._pendingTriggers.clear();
+        this._pendingRepublishDiscovery = false;
+
+        let configs = 0;
+        if (republishDiscovery) {
+            const haDiscovery = this.getHaDiscovery();
+            if (haDiscovery && typeof haDiscovery.republishDiscoveryConfigs === 'function') {
+                configs = haDiscovery.republishDiscoveryConfigs();
+            }
+        }
+
+        const netapps = this.initializationService._resolveGetallNetworks();
+        if (netapps.length === 0) {
+            this.logger.debug(
+                `State resync (${triggers}) had no getall networks configured, so no levels were requested`
+            );
+            return;
+        }
+
+        for (const netapp of netapps) {
+            this.commandQueue.add(
+                `${CGATE_CMD_GET} //${this.settings.cbusname}/${netapp}/* ${CGATE_PARAM_LEVEL}${NEWLINE}`
+            );
+        }
+
+        // Security panels do not answer lighting-style getall (spec §5.9), so
+        // the zone sensors need their own status_request pair or they would stay
+        // stale across exactly the restart this coordinator exists to fix.
+        const securityEventHandler = this.getSecurityEventHandler();
+        const networks = new Set(netapps.map((netapp) => String(netapp).split('/')[0]));
+        if (securityEventHandler && typeof securityEventHandler.requestStatusSync === 'function') {
+            for (const network of networks) {
+                securityEventHandler.requestStatusSync(network, 'resync');
+            }
+        }
+
+        this.logger.info(
+            `State resync (${triggers}): requested levels for ${netapps.length} network/app pair(s), ` +
+            `${networks.size} security status sync(s)` +
+            (republishDiscovery ? `, republished ${configs} discovery config(s)` : '')
+        );
+    }
+}
+
+module.exports = StateResyncCoordinator;

--- a/tests/applicationDecoders/securityDecoder.test.js
+++ b/tests/applicationDecoders/securityDecoder.test.js
@@ -171,9 +171,9 @@ describe('securityDecoder', () => {
                 .toMatchObject({ kind: 'system_arm', mode: 9, modeName: null });
         });
 
-        it('decodes arm_failed with its free-text argument', () => {
+        it('decodes arm_failed as a panel trouble condition, keeping its free-text argument', () => {
             expect(securityDecoder.decodeLine('# security arm_failed //MIDSTRM/254/208 arm_failed_raised #sourceunit=18 OID='))
-                .toMatchObject({ kind: 'arm_failed', detail: 'arm_failed_raised' });
+                .toMatchObject({ kind: 'panel_trouble', condition: 'arm_failed', active: true, detail: 'arm_failed_raised' });
         });
 
         it('decodes alarm_on and alarm_off', () => {
@@ -188,9 +188,54 @@ describe('securityDecoder', () => {
                 .toMatchObject({ kind: 'zone_isolated', zone: '44' });
         });
 
-        it('decodes fire_alarm with its free-text argument', () => {
+        it('decodes fire_alarm as a panel trouble condition, keeping its free-text argument', () => {
             expect(securityDecoder.decodeLine('# security fire_alarm //MIDSTRM/254/208 fire_alarm_raised #sourceunit=18 OID='))
-                .toMatchObject({ kind: 'fire_alarm', detail: 'fire_alarm_raised' });
+                .toMatchObject({ kind: 'panel_trouble', condition: 'fire', active: true, detail: 'fire_alarm_raised' });
+        });
+    });
+
+    // Panel-wide trouble verbs, captured on the 64-zone Cytech panel in issue
+    // #42 on 2026-07-29 (panic press, mains failure, and the disarm that clears
+    // every outstanding trouble condition at once).
+    describe('panel trouble verbs', () => {
+        const cases = [
+            ['mains_failure', 'mains', true],
+            ['mains_restored', 'mains', false],
+            ['low_battery', 'battery', true],
+            ['low_battery_corrected', 'battery', false],
+            ['tamper_on', 'tamper', true],
+            ['tamper_off', 'tamper', false],
+            ['panic_activated', 'panic', true],
+            ['panic_off', 'panic', false],
+            ['panic_cleared', 'panic', false]
+        ];
+
+        it.each(cases)('decodes %s as %s active=%s', (verb, condition, active) => {
+            expect(securityDecoder.decodeLine(`# security ${verb} //MIDSTRM/254/208  #sourceunit=18 OID=`))
+                .toMatchObject({
+                    kind: 'panel_trouble', network: '254', application: '208', condition, active, verb
+                });
+        });
+
+        it('derives active from the _raised/_cleared detail suffix', () => {
+            expect(securityDecoder.decodeLine('# security line_cut_alarm //MIDSTRM/254/208 line_cut_alarm_cleared #sourceunit=18 OID='))
+                .toMatchObject({ condition: 'line', active: false });
+            expect(securityDecoder.decodeLine('# security line_cut_alarm //MIDSTRM/254/208 line_cut_alarm_raised #sourceunit=18 OID='))
+                .toMatchObject({ condition: 'line', active: true });
+        });
+
+        it('treats a bare detail-style verb as raised', () => {
+            expect(securityDecoder.decodeLine('# security fire_alarm //MIDSTRM/254/208  #sourceunit=18 OID='))
+                .toMatchObject({ condition: 'fire', active: true, detail: null });
+        });
+
+        it('still returns null for genuinely unknown verbs so they reach raw capture', () => {
+            expect(securityDecoder.decodeLine('# security some_future_verb //MIDSTRM/254/208 #sourceunit=18 OID=')).toBeNull();
+        });
+
+        it('exposes the condition list in display order', () => {
+            expect(securityDecoder.PANEL_TROUBLE_CONDITIONS)
+                .toEqual(['mains', 'battery', 'tamper', 'panic', 'line', 'arm_failed', 'fire']);
         });
     });
 

--- a/tests/bridgeInitializationService.test.js
+++ b/tests/bridgeInitializationService.test.js
@@ -141,7 +141,7 @@ describe('BridgeInitializationService', () => {
         jest.useRealTimers();
     });
 
-    describe('_sendSecurityStatusRequests', () => {
+    describe('sendSecurityStatusRequests', () => {
         it('delegates a connect-trigger sync per ha_discovery network to the security handler', () => {
             const requestStatusSync = jest.fn();
             const { bridge } = makeBridge({
@@ -150,7 +150,7 @@ describe('BridgeInitializationService', () => {
             });
             bridge.__deps.getSecurityEventHandler = () => ({ requestStatusSync });
             const svc = makeService(bridge);
-            svc._sendSecurityStatusRequests();
+            svc.sendSecurityStatusRequests();
             expect(requestStatusSync).toHaveBeenCalledTimes(2);
             expect(requestStatusSync).toHaveBeenNthCalledWith(1, 254, 'connect');
             expect(requestStatusSync).toHaveBeenNthCalledWith(2, 255, 'connect');
@@ -165,7 +165,7 @@ describe('BridgeInitializationService', () => {
                 });
                 bridge.__deps.getSecurityEventHandler = () => ({ requestStatusSync });
                 const svc = makeService(bridge);
-                svc._sendSecurityStatusRequests();
+                svc.sendSecurityStatusRequests();
             }
             expect(requestStatusSync).not.toHaveBeenCalled();
         });
@@ -177,13 +177,13 @@ describe('BridgeInitializationService', () => {
                 ha_discovery_networks: []
             });
             noNets.__deps.getSecurityEventHandler = () => ({ requestStatusSync });
-            makeService(noNets)._sendSecurityStatusRequests();
+            makeService(noNets).sendSecurityStatusRequests();
             // No handler available (accessor not provided) — must not throw
             const { bridge: noHandler } = makeBridge({
                 cbus_security_app_id: '208',
                 ha_discovery_networks: [254]
             });
-            expect(() => makeService(noHandler)._sendSecurityStatusRequests()).not.toThrow();
+            expect(() => makeService(noHandler).sendSecurityStatusRequests()).not.toThrow();
             expect(requestStatusSync).not.toHaveBeenCalled();
         });
     });

--- a/tests/cgateWebBridge.test.js
+++ b/tests/cgateWebBridge.test.js
@@ -1361,6 +1361,46 @@ describe('CgateWebBridge', () => {
         });
     });
 
+    // Issue #44: neither a Home Assistant restart nor a broker restart restarts
+    // the bridge, so these two signals are the only chance to resend state.
+    describe('state resync wiring', () => {
+        let bridge;
+        beforeEach(() => {
+            bridge = new CgateWebBridge({ ...defaultSettings, cbusip: '127.0.0.1' });
+            bridge._setupEventHandlers();
+            jest.spyOn(bridge.stateResyncCoordinator, 'requestResync').mockImplementation(() => true);
+        });
+        afterEach(() => jest.restoreAllMocks());
+
+        it('resyncs when Home Assistant publishes its online birth message', () => {
+            bridge.mqttManager.emit('message', 'homeassistant/status', 'online');
+            expect(bridge.stateResyncCoordinator.requestResync).toHaveBeenCalledWith('ha-birth');
+        });
+
+        it('ignores the offline will message', () => {
+            bridge.mqttManager.emit('message', 'homeassistant/status', 'offline');
+            expect(bridge.stateResyncCoordinator.requestResync).not.toHaveBeenCalled();
+        });
+
+        it('does not route the birth topic to the command router', () => {
+            jest.spyOn(bridge.mqttCommandRouter, 'routeMessage').mockImplementation(() => {});
+            bridge.mqttManager.emit('message', 'homeassistant/status', 'online');
+            expect(bridge.mqttCommandRouter.routeMessage).not.toHaveBeenCalled();
+        });
+
+        it('still routes normal cbus/write commands', () => {
+            jest.spyOn(bridge.mqttCommandRouter, 'routeMessage').mockImplementation(() => {});
+            bridge.mqttManager.emit('message', 'cbus/write/254/56/4/switch', 'ON');
+            expect(bridge.mqttCommandRouter.routeMessage).toHaveBeenCalledWith('cbus/write/254/56/4/switch', 'ON');
+        });
+
+        it('resyncs and republishes discovery on a broker reconnect', () => {
+            bridge.mqttManager.emit('reconnect');
+            expect(bridge.stateResyncCoordinator.requestResync)
+                .toHaveBeenCalledWith('mqtt-reconnect', { republishDiscovery: true });
+        });
+    });
+
     describe('reloadSettings()', () => {
         let bridge;
         beforeEach(() => {

--- a/tests/cgateWebBridge.test.js
+++ b/tests/cgateWebBridge.test.js
@@ -484,7 +484,11 @@ describe('CgateWebBridge', () => {
 
                 bridge._handleAllConnected();
 
-                expect(addSpy).toHaveBeenCalledWith(expect.stringContaining('GET //TestProject/254/56/* level'));
+                // Startup passes no queue options, so this getall keeps default
+                // (normal) priority; the resync path is the one that uses 'bulk'.
+                expect(addSpy).toHaveBeenCalledWith(
+                    expect.stringContaining('GET //TestProject/254/56/* level'), {}
+                );
             });
 
             it('should set up periodic getall when enabled', () => {
@@ -1372,20 +1376,9 @@ describe('CgateWebBridge', () => {
         });
         afterEach(() => jest.restoreAllMocks());
 
-        it('resyncs when Home Assistant publishes its online birth message', () => {
-            bridge.mqttManager.emit('message', 'homeassistant/status', 'online');
+        it('resyncs when Home Assistant comes online', () => {
+            bridge.mqttManager.emit('haOnline');
             expect(bridge.stateResyncCoordinator.requestResync).toHaveBeenCalledWith('ha-birth');
-        });
-
-        it('ignores the offline will message', () => {
-            bridge.mqttManager.emit('message', 'homeassistant/status', 'offline');
-            expect(bridge.stateResyncCoordinator.requestResync).not.toHaveBeenCalled();
-        });
-
-        it('does not route the birth topic to the command router', () => {
-            jest.spyOn(bridge.mqttCommandRouter, 'routeMessage').mockImplementation(() => {});
-            bridge.mqttManager.emit('message', 'homeassistant/status', 'online');
-            expect(bridge.mqttCommandRouter.routeMessage).not.toHaveBeenCalled();
         });
 
         it('still routes normal cbus/write commands', () => {
@@ -1394,10 +1387,9 @@ describe('CgateWebBridge', () => {
             expect(bridge.mqttCommandRouter.routeMessage).toHaveBeenCalledWith('cbus/write/254/56/4/switch', 'ON');
         });
 
-        it('resyncs and republishes discovery on a broker reconnect', () => {
+        it('resyncs on a broker reconnect', () => {
             bridge.mqttManager.emit('reconnect');
-            expect(bridge.stateResyncCoordinator.requestResync)
-                .toHaveBeenCalledWith('mqtt-reconnect', { republishDiscovery: true });
+            expect(bridge.stateResyncCoordinator.requestResync).toHaveBeenCalledWith('mqtt-reconnect');
         });
     });
 

--- a/tests/haDiscovery.test.js
+++ b/tests/haDiscovery.test.js
@@ -114,7 +114,10 @@ describe('HaDiscovery', () => {
     describe('Constructor', () => {
         it('should initialize with correct properties', () => {
             expect(haDiscovery.settings).toBe(mockSettings);
-            expect(haDiscovery._publish).toBe(mockPublishFn);
+            // _publish wraps the injected fn to cache config payloads for replay
+            // (issue #44), so assert delegation rather than identity.
+            haDiscovery._publish('some/topic', 'payload', { retain: true });
+            expect(mockPublishFn).toHaveBeenCalledWith('some/topic', 'payload', { retain: true });
             expect(haDiscovery._sendCommand).toBe(mockSendCommandFn);
             expect(haDiscovery.treeBufferParts).toEqual([]);
             expect(haDiscovery.treeNetwork).toBeNull();
@@ -3256,5 +3259,67 @@ describe('HaDiscovery — entity type from the driving unit (issues #38, #37)', 
 
         expect(() => d._publishDiscoveryFromTree('254', UNIT_TREE)).toThrow('boom');
         expect(d._unitTypeIndex).toBeNull();
+    });
+});
+
+describe('HaDiscovery — discovery config replay (issue #44)', () => {
+    let publishFn;
+    let d;
+
+    beforeEach(() => {
+        publishFn = jest.fn();
+        d = new HaDiscovery(
+            { ha_discovery_enabled: true, ha_discovery_prefix: 'homeassistant', cbus_security_app_id: '208' },
+            publishFn,
+            jest.fn()
+        );
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+    afterEach(() => jest.restoreAllMocks());
+
+    it('replays every published discovery config payload retained', () => {
+        d.ensureSecurityZoneDiscovery('254', '208', '13');
+        publishFn.mockClear();
+
+        expect(d.republishDiscoveryConfigs()).toBe(1);
+        expect(publishFn).toHaveBeenCalledWith(
+            'homeassistant/binary_sensor/cgateweb_254_208_13/config',
+            expect.stringContaining('cgateweb_254_208_13'),
+            expect.objectContaining({ retain: true })
+        );
+    });
+
+    it('replays each config once regardless of how many entities exist', () => {
+        d.ensureSecurityZoneDiscovery('254', '208', '13');
+        d.ensureSecurityZoneDiscovery('254', '208', '14');
+        d.ensureSecurityPanelDiscovery('254', '208');
+        publishFn.mockClear();
+
+        // 2 zones + 7 panel conditions
+        expect(d.republishDiscoveryConfigs()).toBe(9);
+    });
+
+    it('does not replay a retracted config', () => {
+        d.ensureSecurityZoneDiscovery('254', '208', '13');
+        d.exclude.add('254/208/14');
+        d.ensureSecurityZoneDiscovery('254', '208', '14'); // retracts with an empty payload
+        publishFn.mockClear();
+
+        expect(d.republishDiscoveryConfigs()).toBe(1);
+        expect(publishFn).not.toHaveBeenCalledWith(
+            'homeassistant/binary_sensor/cgateweb_254_208_14/config',
+            expect.anything(),
+            expect.anything()
+        );
+    });
+
+    it('returns zero when nothing has been published yet', () => {
+        expect(d.republishDiscoveryConfigs()).toBe(0);
+        expect(publishFn).not.toHaveBeenCalled();
+    });
+
+    it('does not record non-config state publishes', () => {
+        d._publish('cbus/read/254/208/13/state', 'ON', { retain: true });
+        expect(d.republishDiscoveryConfigs()).toBe(0);
     });
 });

--- a/tests/mqttManager.test.js
+++ b/tests/mqttManager.test.js
@@ -484,12 +484,31 @@ describe('MqttManager', () => {
 
             it('derives the birth topic from ha_discovery_prefix', () => {
                 mqttManager.settings.ha_discovery_prefix = 'ha-custom';
+                mqttManager._haStatusTopic = null; // clear the memo
                 expect(mqttManager.haStatusTopic).toBe('ha-custom/status');
             });
 
             it('prefers an explicit haStatusTopic override', () => {
                 mqttManager.settings.haStatusTopic = 'somewhere/else';
+                mqttManager._haStatusTopic = null;
                 expect(mqttManager.haStatusTopic).toBe('somewhere/else');
+            });
+
+            it('emits haOnline for an online birth payload, not a generic message', () => {
+                const onHaOnline = jest.fn();
+                const onMessage = jest.fn();
+                mqttManager.on('haOnline', onHaOnline);
+                mqttManager.on('message', onMessage);
+                mqttManager._handleMessage('homeassistant/status', Buffer.from('online'), {});
+                expect(onHaOnline).toHaveBeenCalledTimes(1);
+                expect(onMessage).not.toHaveBeenCalled();
+            });
+
+            it('ignores the offline will payload', () => {
+                const onHaOnline = jest.fn();
+                mqttManager.on('haOnline', onHaOnline);
+                mqttManager._handleMessage('homeassistant/status', Buffer.from('offline'), {});
+                expect(onHaOnline).not.toHaveBeenCalled();
             });
 
             it('does not emit reconnect on the first connect', () => {

--- a/tests/mqttManager.test.js
+++ b/tests/mqttManager.test.js
@@ -468,10 +468,42 @@ describe('MqttManager', () => {
                     if (callback) callback(null);
                     return true;
                 });
-                
+
                 mockClient.emit('connect');
-                
+
                 expect(loggerSpy).toHaveBeenCalledWith(expect.stringContaining('Subscribed to MQTT topic'));
+            });
+
+            // Issue #44: a HA restart leaves the add-on running, so its birth
+            // message is the only signal that entity state needs resending.
+            it('subscribes to the Home Assistant birth topic', () => {
+                const subscribeSpy = jest.spyOn(mqttManager, 'subscribe');
+                mockClient.emit('connect');
+                expect(subscribeSpy).toHaveBeenCalledWith('homeassistant/status', expect.any(Function));
+            });
+
+            it('derives the birth topic from ha_discovery_prefix', () => {
+                mqttManager.settings.ha_discovery_prefix = 'ha-custom';
+                expect(mqttManager.haStatusTopic).toBe('ha-custom/status');
+            });
+
+            it('prefers an explicit haStatusTopic override', () => {
+                mqttManager.settings.haStatusTopic = 'somewhere/else';
+                expect(mqttManager.haStatusTopic).toBe('somewhere/else');
+            });
+
+            it('does not emit reconnect on the first connect', () => {
+                const emitSpy = jest.spyOn(mqttManager, 'emit');
+                mockClient.emit('connect');
+                expect(emitSpy).not.toHaveBeenCalledWith('reconnect');
+            });
+
+            it('emits reconnect on a mid-session reconnect', () => {
+                mockClient.emit('connect');
+                const emitSpy = jest.spyOn(mqttManager, 'emit');
+                mockClient.emit('close');
+                mockClient.emit('connect');
+                expect(emitSpy).toHaveBeenCalledWith('reconnect');
             });
         });
 

--- a/tests/securityDiscovery.test.js
+++ b/tests/securityDiscovery.test.js
@@ -244,4 +244,84 @@ describe('HaDiscovery — app 208 security zones', () => {
             expect(publishFn).not.toHaveBeenCalled();
         });
     });
+
+    describe('panel trouble sensors', () => {
+        const CONDITIONS = ['mains', 'battery', 'tamper', 'panic', 'line', 'arm_failed', 'fire'];
+
+        function panelPayloads() {
+            return publishFn.mock.calls
+                .filter(c => c[0].includes('_208_panel_'))
+                .map(c => ({ topic: c[0], payload: c[1] ? JSON.parse(c[1]) : null }));
+        }
+
+        function payloadFor(condition) {
+            const found = panelPayloads().find(p => p.topic.endsWith(`_panel_${condition}/config`));
+            return found && found.payload;
+        }
+
+        it('publishes one binary_sensor per condition', () => {
+            expect(d.ensureSecurityPanelDiscovery('254', '208')).toBe(true);
+            expect(panelPayloads()).toHaveLength(7);
+            for (const condition of CONDITIONS) {
+                expect(payloadFor(condition)).toBeDefined();
+            }
+        });
+
+        it('groups them all on one shared panel device as diagnostics', () => {
+            d.ensureSecurityPanelDiscovery('254', '208');
+            for (const condition of CONDITIONS) {
+                const payload = payloadFor(condition);
+                expect(payload.entity_category).toBe('diagnostic');
+                expect(payload.device.identifiers).toEqual(['cgateweb_254_208_panel']);
+                expect(payload.device.name).toBe('C-Bus Security Panel 254/208');
+                expect(payload.device.model).toBe('C-Bus Security Panel');
+            }
+        });
+
+        it('points each sensor at its own panel state topic', () => {
+            d.ensureSecurityPanelDiscovery('254', '208');
+            const mains = payloadFor('mains');
+            expect(mains.state_topic).toBe('cbus/read/254/208/panel/mains/state');
+            expect(mains.unique_id).toBe('cgateweb_254_208_panel_mains');
+            expect(mains.payload_on).toBe('ON');
+            expect(mains.payload_off).toBe('OFF');
+            expect(mains.name).toBe('Mains power');
+        });
+
+        it('assigns the agreed device classes', () => {
+            d.ensureSecurityPanelDiscovery('254', '208');
+            expect(payloadFor('mains').device_class).toBe('problem');
+            expect(payloadFor('battery').device_class).toBe('battery');
+            expect(payloadFor('tamper').device_class).toBe('tamper');
+            expect(payloadFor('panic').device_class).toBe('safety');
+            expect(payloadFor('line').device_class).toBe('problem');
+            expect(payloadFor('arm_failed').device_class).toBe('problem');
+            expect(payloadFor('fire').device_class).toBe('smoke');
+        });
+
+        it('is idempotent', () => {
+            expect(d.ensureSecurityPanelDiscovery('254', '208')).toBe(true);
+            publishFn.mockClear();
+            expect(d.ensureSecurityPanelDiscovery('254', '208')).toBe(false);
+            expect(publishFn).not.toHaveBeenCalled();
+        });
+
+        it('retracts all seven and skips an excluded panel', () => {
+            d.exclude.add('254/208/panel');
+            expect(d.ensureSecurityPanelDiscovery('254', '208')).toBe(false);
+            const retracted = panelPayloads().filter(p => p.payload === null);
+            expect(retracted).toHaveLength(7);
+        });
+
+        it('publishes nothing when HA discovery is disabled', () => {
+            const off = new HaDiscovery(
+                { ha_discovery_enabled: false, ha_discovery_prefix: 'homeassistant', cbus_security_app_id: '208' },
+                publishFn,
+                jest.fn()
+            );
+            publishFn.mockClear();
+            expect(off.ensureSecurityPanelDiscovery('254', '208')).toBe(false);
+            expect(publishFn).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/tests/securityEventHandler.test.js
+++ b/tests/securityEventHandler.test.js
@@ -175,9 +175,33 @@ describe('SecurityEventHandler', () => {
             handler.handleLine(SYSTEM_ARM_LINE); // mode 3 = armed
             handler.handleLine('# security system_arm //MIDSTRM/254/208 0 #sourceunit=18 OID=');
             handler.handleLine('# security arm_not_ready //MIDSTRM/254/208/44  #sourceunit=18 OID=');
-            expect(onEventLog).toHaveBeenNthCalledWith(1, expect.objectContaining({ group: '0', level: 255, type: 'on' }));
-            expect(onEventLog).toHaveBeenNthCalledWith(2, expect.objectContaining({ group: '0', level: 0, type: 'off' }));
+            // Panel-wide verbs carry no zone, so group is null and the UI renders
+            // the address as net/app rather than a bogus net/app/0.
+            expect(onEventLog).toHaveBeenNthCalledWith(1, expect.objectContaining({ group: null, level: 255, type: 'on' }));
+            expect(onEventLog).toHaveBeenNthCalledWith(2, expect.objectContaining({ group: null, level: 0, type: 'off' }));
             expect(onEventLog).toHaveBeenNthCalledWith(3, expect.objectContaining({ group: '44', level: 0, type: 'update' }));
+        });
+
+        it('describes zone entries so the UI need not render a level percentage', () => {
+            const onEventLog = jest.fn();
+            const deps = makeDeps({ onEventLog });
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine(ZONE_UNSEALED_LINE);
+            handler.handleLine(ZONE_SEALED_LINE);
+            expect(onEventLog).toHaveBeenNthCalledWith(1, expect.objectContaining({ description: 'Zone unsealed' }));
+            expect(onEventLog).toHaveBeenNthCalledWith(2, expect.objectContaining({ description: 'Zone sealed' }));
+        });
+
+        it('describes system entries with the same text used for the INFO log', () => {
+            const onEventLog = jest.fn();
+            const deps = makeDeps({ onEventLog });
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine(SYSTEM_ARM_LINE);
+            handler.handleLine('# security system_arm //MIDSTRM/254/208 0 #sourceunit=18 OID=');
+            handler.handleLine('# security zone_isolated //MIDSTRM/254/208/44  #sourceunit=18 OID=');
+            expect(onEventLog).toHaveBeenNthCalledWith(1, expect.objectContaining({ description: 'System armed (Day mode)' }));
+            expect(onEventLog).toHaveBeenNthCalledWith(2, expect.objectContaining({ description: 'System disarmed' }));
+            expect(onEventLog).toHaveBeenNthCalledWith(3, expect.objectContaining({ description: 'Zone 44 bypassed' }));
         });
 
         it('does not flood the stream for status reports or echoes', () => {

--- a/tests/securityEventHandler.test.js
+++ b/tests/securityEventHandler.test.js
@@ -138,10 +138,23 @@ describe('SecurityEventHandler', () => {
             ['# security exit_delay_started //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Exit delay started (254/208)'],
             ['# security arm_not_ready //MIDSTRM/254/208/44  #sourceunit=18 OID=', 'C-Bus Security: Zone 44 open — not ready to arm (254/208)'],
             ['# security zone_isolated //MIDSTRM/254/208/44  #sourceunit=18 OID=', 'C-Bus Security: Zone 44 bypassed (254/208)'],
-            ['# security arm_failed //MIDSTRM/254/208 arm_failed_raised #sourceunit=18 OID=', 'C-Bus Security: Arm failed (arm_failed_raised) (254/208)'],
             ['# security alarm_on //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Alarm on (254/208)'],
             ['# security alarm_off //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Alarm off (254/208)'],
-            ['# security fire_alarm //MIDSTRM/254/208 fire_alarm_raised #sourceunit=18 OID=', 'C-Bus Security: Fire alarm (fire_alarm_raised) (254/208)']
+            // Panel trouble conditions. The raw _raised/_cleared argument is
+            // dropped from the log line: the sense is already in the wording.
+            ['# security arm_failed //MIDSTRM/254/208 arm_failed_raised #sourceunit=18 OID=', 'C-Bus Security: Arm failed (254/208)'],
+            ['# security arm_failed //MIDSTRM/254/208 arm_failed_cleared #sourceunit=18 OID=', 'C-Bus Security: Arm failure cleared (254/208)'],
+            ['# security fire_alarm //MIDSTRM/254/208 fire_alarm_raised #sourceunit=18 OID=', 'C-Bus Security: Fire alarm (254/208)'],
+            ['# security fire_alarm //MIDSTRM/254/208 fire_alarm_cleared #sourceunit=18 OID=', 'C-Bus Security: Fire alarm cleared (254/208)'],
+            ['# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Mains power failure (254/208)'],
+            ['# security mains_restored //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Mains power restored (254/208)'],
+            ['# security low_battery //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Battery low (254/208)'],
+            ['# security low_battery_corrected //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Battery restored (254/208)'],
+            ['# security tamper_on //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Tamper detected (254/208)'],
+            ['# security tamper_off //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Tamper cleared (254/208)'],
+            ['# security panic_activated //MIDSTRM/254/208  #sourceunit=18 OID=', 'C-Bus Security: Panic activated (254/208)'],
+            ['# security line_cut_alarm //MIDSTRM/254/208 line_cut_alarm_raised #sourceunit=18 OID=', 'C-Bus Security: Phone line cut (254/208)'],
+            ['# security line_cut_alarm //MIDSTRM/254/208 line_cut_alarm_cleared #sourceunit=18 OID=', 'C-Bus Security: Phone line restored (254/208)']
         ];
 
         it.each(cases)('logs %s', (line, expected) => {

--- a/tests/securityEventHandler.test.js
+++ b/tests/securityEventHandler.test.js
@@ -394,6 +394,27 @@ describe('SecurityEventHandler', () => {
             expect(deps.sendCommand).toHaveBeenCalledTimes(4);
         });
 
+        // Issue #44: HA can restart any number of times in one bridge session,
+        // and every restart genuinely needs the zone state resent. Rate limiting
+        // for this trigger is the resync coordinator's debounce, not the dedupe.
+        it('exempts the resync trigger from the once-per-session dedupe', () => {
+            const deps = makeDeps({ cbusname: 'MIDSTRM', sendCommand: jest.fn() });
+            const handler = new SecurityEventHandler(deps);
+            handler.requestStatusSync('254', 'connect');
+            handler.requestStatusSync('254', 'sync');
+            expect(handler.requestStatusSync('254', 'resync')).toBe(true);
+            expect(handler.requestStatusSync('254', 'resync')).toBe(true);
+            expect(deps.sendCommand).toHaveBeenCalledTimes(8); // 4 pairs
+        });
+
+        it('does not let a resync consume the early or post-762 slots', () => {
+            const deps = makeDeps({ cbusname: 'MIDSTRM', sendCommand: jest.fn() });
+            const handler = new SecurityEventHandler(deps);
+            handler.requestStatusSync('254', 'resync');
+            expect(handler.requestStatusSync('254', 'connect')).toBe(true);
+            expect(handler.requestStatusSync('254', 'sync')).toBe(true);
+        });
+
         it('fires the early pair on first traffic when connect never happened (no-762 sessions)', () => {
             const deps = makeDeps({ cbusname: 'MIDSTRM', sendCommand: jest.fn() });
             const handler = new SecurityEventHandler(deps);

--- a/tests/securityEventHandler.test.js
+++ b/tests/securityEventHandler.test.js
@@ -109,7 +109,9 @@ describe('SecurityEventHandler', () => {
         expect(deps.sendCommand).not.toHaveBeenCalled();
     });
 
-    it('consumes system-state verbs without publishing MQTT state', () => {
+    // arm_failed and fire_alarm are deliberately absent: they are panel trouble
+    // conditions now and do publish state (see 'panel trouble conditions').
+    it('consumes arm-progress and alarm verbs without publishing MQTT state', () => {
         const deps = makeDeps();
         const handler = new SecurityEventHandler(deps);
         for (const line of [
@@ -117,11 +119,9 @@ describe('SecurityEventHandler', () => {
             '# security arm_ready //MIDSTRM/254/208  #sourceunit=18 OID=',
             '# security arm_not_ready //MIDSTRM/254/208/44  #sourceunit=18 OID=',
             '# security exit_delay_started //MIDSTRM/254/208  #sourceunit=18 OID=',
-            '# security arm_failed //MIDSTRM/254/208 arm_failed_raised #sourceunit=18 OID=',
             '# security alarm_on //MIDSTRM/254/208  #sourceunit=18 OID=',
             '# security alarm_off //MIDSTRM/254/208  #sourceunit=18 OID=',
-            '# security zone_isolated //MIDSTRM/254/208/44  #sourceunit=18 OID=',
-            '# security fire_alarm //MIDSTRM/254/208 fire_alarm_raised #sourceunit=18 OID='
+            '# security zone_isolated //MIDSTRM/254/208/44  #sourceunit=18 OID='
         ]) {
             expect(handler.handleLine(line)).toBe(true);
         }
@@ -162,6 +162,71 @@ describe('SecurityEventHandler', () => {
             const handler = new SecurityEventHandler(deps);
             handler.handleLine(line);
             expect(deps.logger.info).toHaveBeenCalledWith(expected);
+        });
+    });
+
+    describe('panel trouble conditions', () => {
+        it('publishes ON for a mains failure and OFF when restored', () => {
+            const deps = makeDeps();
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine('# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=');
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/mains', { kind: 'security_panel', active: true }
+            );
+            handler.handleLine('# security mains_restored //MIDSTRM/254/208  #sourceunit=18 OID=');
+            expect(deps.eventPublisher.publishReading).toHaveBeenLastCalledWith(
+                '254', '208', 'panel/mains', { kind: 'security_panel', active: false }
+            );
+        });
+
+        it('does not republish a repeated raise', () => {
+            const deps = makeDeps();
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine('# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=');
+            deps.eventPublisher.publishReading.mockClear();
+            handler.handleLine('# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=');
+            expect(deps.eventPublisher.publishReading).not.toHaveBeenCalled();
+        });
+
+        it('clears panic on disarm even though the panel sends no panic_off', () => {
+            const deps = makeDeps();
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine('# security panic_activated //MIDSTRM/254/208  #sourceunit=18 OID=');
+            handler.handleLine('# security system_arm //MIDSTRM/254/208 0 #sourceunit=18 OID=');
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/panic', { kind: 'security_panel', active: false }
+            );
+        });
+
+        it('triggers panel discovery on the first trouble event', () => {
+            const ensureSecurityPanelDiscovery = jest.fn();
+            const deps = makeDeps({
+                getHaDiscovery: () => ({ ensureSecurityZoneDiscovery: jest.fn(), ensureSecurityPanelDiscovery })
+            });
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine('# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=');
+            expect(ensureSecurityPanelDiscovery).toHaveBeenCalledWith('254', '208');
+        });
+
+        it('seeds tamper from a status_report_1 so the panel sensor reflects reality', () => {
+            const deps = makeDeps();
+            const handler = new SecurityEventHandler(deps);
+            // arm state 0, tamper 255 (active), panic 0, then zone values.
+            handler.handleLine('# security status_report_1 //MIDSTRM/254/208 0 255 0 0 0 0 #sourceunit=18 OID=');
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/tamper', { kind: 'security_panel', active: true }
+            );
+        });
+
+        it('consumes the line and logs at INFO with a Live Events description', () => {
+            const onEventLog = jest.fn();
+            const deps = makeDeps({ onEventLog });
+            const handler = new SecurityEventHandler(deps);
+            expect(handler.handleLine('# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=')).toBe(true);
+            expect(deps.logger.info).toHaveBeenCalledWith('C-Bus Security: Mains power failure (254/208)');
+            expect(onEventLog).toHaveBeenCalledWith(expect.objectContaining({
+                group: null, description: 'Mains power failure'
+            }));
         });
     });
 

--- a/tests/securityPanelConditions.test.js
+++ b/tests/securityPanelConditions.test.js
@@ -1,0 +1,76 @@
+const {
+    PANEL_CONDITIONS,
+    PANEL_TROUBLE_CONDITIONS,
+    PANEL_TROUBLE_VERBS,
+    PANEL_TROUBLE_DETAIL_VERBS,
+    CLEARED_ON_DISARM,
+    CLEARED_ON_ARM,
+    describePanelCondition
+} = require('../src/securityPanelConditions');
+
+// This registry exists so one condition's wire verbs, HA metadata and log
+// wording live in one record. These tests are the guard rail: before it existed
+// the same knowledge sat in seven tables across four modules, and adding an
+// eighth condition while missing one table failed silently (an entity named
+// `undefined`, or a log line showing the raw condition id).
+describe('securityPanelConditions', () => {
+    it('gives every condition the fields all four consumers need', () => {
+        for (const condition of PANEL_CONDITIONS) {
+            expect(typeof condition.id).toBe('string');
+            expect(typeof condition.name).toBe('string');
+            expect(typeof condition.deviceClass).toBe('string');
+            expect(typeof condition.raisedText).toBe('string');
+            expect(typeof condition.clearedText).toBe('string');
+            // Every condition must be reachable from the wire: either it names
+            // its own sense, or it carries it in a _raised/_cleared argument.
+            expect(Boolean(condition.raiseVerb || condition.detailVerb)).toBe(true);
+        }
+    });
+
+    it('has no duplicate condition ids', () => {
+        expect(new Set(PANEL_TROUBLE_CONDITIONS).size).toBe(PANEL_TROUBLE_CONDITIONS.length);
+    });
+
+    it('maps no verb to two different conditions', () => {
+        const verbs = [...PANEL_TROUBLE_VERBS.keys(), ...PANEL_TROUBLE_DETAIL_VERBS.keys()];
+        expect(new Set(verbs).size).toBe(verbs.length);
+    });
+
+    it('derives the verb maps from the records', () => {
+        expect(PANEL_TROUBLE_VERBS.get('mains_failure')).toEqual({ condition: 'mains', active: true });
+        expect(PANEL_TROUBLE_VERBS.get('mains_restored')).toEqual({ condition: 'mains', active: false });
+        // panic accepts two inferred clear spellings, neither of them captured.
+        expect(PANEL_TROUBLE_VERBS.get('panic_off')).toEqual({ condition: 'panic', active: false });
+        expect(PANEL_TROUBLE_VERBS.get('panic_cleared')).toEqual({ condition: 'panic', active: false });
+        expect(PANEL_TROUBLE_DETAIL_VERBS.get('line_cut_alarm')).toBe('line');
+    });
+
+    it('derives the derived-clear lists from the records', () => {
+        expect(CLEARED_ON_DISARM.sort()).toEqual(['arm_failed', 'fire', 'panic']);
+        expect(CLEARED_ON_ARM).toEqual(['arm_failed']);
+    });
+
+    it('gives every condition some route back to clear, so none can latch on forever', () => {
+        // The failure this guards against: a condition that can be raised but has
+        // no clear verb and no derived clear would pin its sensor ON until the
+        // bridge restarts. panic deliberately has both an inferred clear verb and
+        // a derived clear -- we never captured panic_off, so we accept it if it
+        // arrives and fall back to the disarm clear if it does not.
+        for (const condition of PANEL_CONDITIONS) {
+            const clearable = Boolean(condition.clearVerb)
+                || Boolean(condition.detailVerb)   // carries its own _cleared form
+                || condition.clearedOnDisarm === true
+                || condition.clearedOnArm === true;
+            expect({ id: condition.id, clearable }).toEqual({ id: condition.id, clearable: true });
+        }
+    });
+
+    it('describes both senses of a condition', () => {
+        expect(describePanelCondition('mains', true)).toBe('Mains power failure');
+        expect(describePanelCondition('mains', false)).toBe('Mains power restored');
+    });
+
+    it('falls back to the raw id for an unknown condition', () => {
+        expect(describePanelCondition('not_a_condition', true)).toBe('not_a_condition');
+    });
+});

--- a/tests/securityPanelState.test.js
+++ b/tests/securityPanelState.test.js
@@ -1,0 +1,134 @@
+const SecurityPanelState = require('../src/securityPanelState');
+
+describe('SecurityPanelState', () => {
+    let state;
+
+    beforeEach(() => {
+        state = new SecurityPanelState();
+    });
+
+    const trouble = (condition, active, network = '254') => ({
+        kind: 'panel_trouble', network, condition, active
+    });
+
+    describe('transitions', () => {
+        it('reports a newly raised condition as changed', () => {
+            expect(state.applyReading(trouble('mains', true)))
+                .toEqual([{ condition: 'mains', active: true }]);
+        });
+
+        it('dedupes a repeated raise', () => {
+            state.applyReading(trouble('mains', true));
+            expect(state.applyReading(trouble('mains', true))).toEqual([]);
+        });
+
+        it('reports the clear that follows a raise', () => {
+            state.applyReading(trouble('mains', true));
+            expect(state.applyReading(trouble('mains', false)))
+                .toEqual([{ condition: 'mains', active: false }]);
+        });
+
+        it('dedupes a clear for a condition that was never raised', () => {
+            expect(state.applyReading(trouble('mains', false))).toEqual([]);
+        });
+
+        it('tracks networks independently', () => {
+            state.applyReading(trouble('mains', true, '254'));
+            expect(state.applyReading(trouble('mains', true, '200')))
+                .toEqual([{ condition: 'mains', active: true }]);
+        });
+
+        it('ignores an unknown condition', () => {
+            expect(state.applyReading(trouble('not_a_condition', true))).toEqual([]);
+        });
+    });
+
+    describe('derived clears', () => {
+        it('clears panic, arm_failed and fire on disarm', () => {
+            for (const condition of ['panic', 'arm_failed', 'fire']) {
+                state.applyReading(trouble(condition, true));
+            }
+            const cleared = state.applyReading({ kind: 'system_arm', network: '254', mode: 0 });
+            expect(cleared.map((c) => c.condition).sort()).toEqual(['arm_failed', 'fire', 'panic']);
+            expect(cleared.every((c) => c.active === false)).toBe(true);
+        });
+
+        it('leaves mains and battery alone on disarm - a power fault is not cleared by disarming', () => {
+            state.applyReading(trouble('mains', true));
+            state.applyReading(trouble('battery', true));
+            expect(state.applyReading({ kind: 'system_arm', network: '254', mode: 0 })).toEqual([]);
+            expect(state.getState('254').mains).toBe(true);
+        });
+
+        it('clears arm_failed on a successful arm but leaves panic alone', () => {
+            state.applyReading(trouble('arm_failed', true));
+            state.applyReading(trouble('panic', true));
+            expect(state.applyReading({ kind: 'system_arm', network: '254', mode: 1 }))
+                .toEqual([{ condition: 'arm_failed', active: false }]);
+            expect(state.getState('254').panic).toBe(true);
+        });
+
+        it('reports nothing when a disarm has nothing to clear', () => {
+            expect(state.applyReading({ kind: 'system_arm', network: '254', mode: 0 })).toEqual([]);
+        });
+    });
+
+    describe('status report seeding', () => {
+        it('seeds tamper and panic from the report bytes', () => {
+            expect(state.seedFromStatusReport({
+                kind: 'status_report_1', network: '254', tamperActive: true, panicActive: false
+            })).toEqual([{ condition: 'tamper', active: true }]);
+            expect(state.getState('254').tamper).toBe(true);
+        });
+
+        it('seeds both when both are active', () => {
+            const seeded = state.seedFromStatusReport({
+                kind: 'status_report_1', network: '254', tamperActive: true, panicActive: true
+            });
+            expect(seeded.map((c) => c.condition).sort()).toEqual(['panic', 'tamper']);
+        });
+
+        it('corrects an assumed-healthy seed when the first report says otherwise', () => {
+            state.initialStates('254');
+            expect(state.seedFromStatusReport({
+                kind: 'status_report_1', network: '254', tamperActive: true, panicActive: false
+            })).toEqual([{ condition: 'tamper', active: true }]);
+        });
+
+        it('ignores reports that carry no tamper or panic bytes', () => {
+            expect(state.seedFromStatusReport({ kind: 'status_report_2', network: '254' })).toEqual([]);
+        });
+    });
+
+    describe('initialStates', () => {
+        it('returns all seven conditions defaulting to inactive', () => {
+            const initial = state.initialStates('254');
+            expect(initial).toHaveLength(7);
+            expect(initial.map((c) => c.condition)).toEqual(
+                ['mains', 'battery', 'tamper', 'panic', 'line', 'arm_failed', 'fire']
+            );
+            expect(initial.every((c) => c.active === false)).toBe(true);
+        });
+
+        it('reflects state already learned from a status report', () => {
+            state.seedFromStatusReport({
+                kind: 'status_report_1', network: '254', tamperActive: true, panicActive: false
+            });
+            const initial = state.initialStates('254');
+            expect(initial.find((c) => c.condition === 'tamper').active).toBe(true);
+            expect(initial.find((c) => c.condition === 'panic').active).toBe(false);
+        });
+    });
+
+    describe('getState', () => {
+        it('returns all seven conditions for an untouched network', () => {
+            expect(Object.keys(state.getState('254'))).toHaveLength(7);
+        });
+
+        it('does not leak mutations back into the tracker', () => {
+            const snapshot = state.getState('254');
+            snapshot.mains = true;
+            expect(state.getState('254').mains).toBe(false);
+        });
+    });
+});

--- a/tests/securityPanelState.test.js
+++ b/tests/securityPanelState.test.js
@@ -11,6 +11,9 @@ describe('SecurityPanelState', () => {
         kind: 'panel_trouble', network, condition, active
     });
 
+    const activeFor = (tracker, network, condition) =>
+        tracker.initialStates(network).find((c) => c.condition === condition).active;
+
     describe('transitions', () => {
         it('reports a newly raised condition as changed', () => {
             expect(state.applyReading(trouble('mains', true)))
@@ -57,7 +60,7 @@ describe('SecurityPanelState', () => {
             state.applyReading(trouble('mains', true));
             state.applyReading(trouble('battery', true));
             expect(state.applyReading({ kind: 'system_arm', network: '254', mode: 0 })).toEqual([]);
-            expect(state.getState('254').mains).toBe(true);
+            expect(activeFor(state, '254', 'mains')).toBe(true);
         });
 
         it('clears arm_failed on a successful arm but leaves panic alone', () => {
@@ -65,7 +68,7 @@ describe('SecurityPanelState', () => {
             state.applyReading(trouble('panic', true));
             expect(state.applyReading({ kind: 'system_arm', network: '254', mode: 1 }))
                 .toEqual([{ condition: 'arm_failed', active: false }]);
-            expect(state.getState('254').panic).toBe(true);
+            expect(activeFor(state, '254', 'panic')).toBe(true);
         });
 
         it('reports nothing when a disarm has nothing to clear', () => {
@@ -78,7 +81,7 @@ describe('SecurityPanelState', () => {
             expect(state.seedFromStatusReport({
                 kind: 'status_report_1', network: '254', tamperActive: true, panicActive: false
             })).toEqual([{ condition: 'tamper', active: true }]);
-            expect(state.getState('254').tamper).toBe(true);
+            expect(activeFor(state, '254', 'tamper')).toBe(true);
         });
 
         it('seeds both when both are active', () => {
@@ -120,15 +123,4 @@ describe('SecurityPanelState', () => {
         });
     });
 
-    describe('getState', () => {
-        it('returns all seven conditions for an untouched network', () => {
-            expect(Object.keys(state.getState('254'))).toHaveLength(7);
-        });
-
-        it('does not leak mutations back into the tracker', () => {
-            const snapshot = state.getState('254');
-            snapshot.mains = true;
-            expect(state.getState('254').mains).toBe(false);
-        });
-    });
 });

--- a/tests/stateResyncCoordinator.test.js
+++ b/tests/stateResyncCoordinator.test.js
@@ -1,0 +1,166 @@
+const StateResyncCoordinator = require('../src/stateResyncCoordinator');
+
+describe('StateResyncCoordinator', () => {
+    let settings;
+    let commandQueue;
+    let haDiscovery;
+    let securityEventHandler;
+    let initializationService;
+    let logger;
+    let coordinator;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        settings = {
+            cbusname: 'TEST',
+            stateResyncOnHaRestart: true,
+            stateResyncOnMqttReconnect: true,
+            stateResyncDebounceMs: 5000
+        };
+        commandQueue = { add: jest.fn() };
+        haDiscovery = { republishDiscoveryConfigs: jest.fn().mockReturnValue(3) };
+        securityEventHandler = { requestStatusSync: jest.fn() };
+        initializationService = { _resolveGetallNetworks: jest.fn().mockReturnValue(['254/56', '254/203']) };
+        logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn() };
+        coordinator = new StateResyncCoordinator({
+            settings,
+            commandQueue,
+            logger,
+            getHaDiscovery: () => haDiscovery,
+            getSecurityEventHandler: () => securityEventHandler,
+            initializationService
+        });
+    });
+
+    afterEach(() => {
+        coordinator.dispose();
+        jest.useRealTimers();
+    });
+
+    describe('getall resync', () => {
+        it('queues a getall per configured net/app', () => {
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).toHaveBeenCalledWith('GET //TEST/254/56/* level\n');
+            expect(commandQueue.add).toHaveBeenCalledWith('GET //TEST/254/203/* level\n');
+        });
+
+        it('does nothing until the debounce elapses', () => {
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(4999);
+            expect(commandQueue.add).not.toHaveBeenCalled();
+        });
+
+        it('logs one INFO summary naming the trigger', () => {
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('ha-birth'));
+        });
+    });
+
+    describe('debounce', () => {
+        it('collapses two triggers inside the window into one resync', () => {
+            coordinator.requestResync('ha-birth');
+            coordinator.requestResync('mqtt-reconnect');
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).toHaveBeenCalledTimes(2); // 2 net/apps, once each
+        });
+
+        it('allows a later resync after the window closes', () => {
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            commandQueue.add.mockClear();
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    describe('discovery republish', () => {
+        it('is skipped for an HA birth, whose retained configs survived', () => {
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(haDiscovery.republishDiscoveryConfigs).not.toHaveBeenCalled();
+        });
+
+        it('runs for a broker reconnect, which may have dropped them', () => {
+            coordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+            jest.advanceTimersByTime(5000);
+            expect(haDiscovery.republishDiscoveryConfigs).toHaveBeenCalledTimes(1);
+        });
+
+        it('stays requested when a collapsed trigger asked for it', () => {
+            coordinator.requestResync('ha-birth');
+            coordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+            jest.advanceTimersByTime(5000);
+            expect(haDiscovery.republishDiscoveryConfigs).toHaveBeenCalledTimes(1);
+        });
+
+        it('survives a missing haDiscovery', () => {
+            haDiscovery = null;
+            coordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+            expect(() => jest.advanceTimersByTime(5000)).not.toThrow();
+            expect(commandQueue.add).toHaveBeenCalled();
+        });
+    });
+
+    describe('security zones', () => {
+        // Security panels don't answer lighting-style getall (spec §5.9), so
+        // without this the new zone sensors would go stale across exactly the
+        // restart this coordinator exists to fix.
+        it('requests a security status sync per distinct network', () => {
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(securityEventHandler.requestStatusSync).toHaveBeenCalledTimes(1);
+            expect(securityEventHandler.requestStatusSync).toHaveBeenCalledWith('254', 'resync');
+        });
+
+        it('survives a missing security handler', () => {
+            securityEventHandler = null;
+            coordinator.requestResync('ha-birth');
+            expect(() => jest.advanceTimersByTime(5000)).not.toThrow();
+        });
+    });
+
+    describe('nothing to do', () => {
+        it('logs at debug and sends nothing when no networks are configured', () => {
+            initializationService._resolveGetallNetworks.mockReturnValue([]);
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).not.toHaveBeenCalled();
+            expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('no getall'));
+        });
+    });
+
+    describe('disable flags', () => {
+        it('honours stateResyncOnHaRestart', () => {
+            settings.stateResyncOnHaRestart = false;
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).not.toHaveBeenCalled();
+        });
+
+        it('honours stateResyncOnMqttReconnect', () => {
+            settings.stateResyncOnMqttReconnect = false;
+            coordinator.requestResync('mqtt-reconnect');
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).not.toHaveBeenCalled();
+        });
+
+        it('still allows the other trigger when one is disabled', () => {
+            settings.stateResyncOnMqttReconnect = false;
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).toHaveBeenCalled();
+        });
+    });
+
+    describe('dispose', () => {
+        it('cancels a pending resync', () => {
+            coordinator.requestResync('ha-birth');
+            coordinator.dispose();
+            jest.advanceTimersByTime(5000);
+            expect(commandQueue.add).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/tests/stateResyncCoordinator.test.js
+++ b/tests/stateResyncCoordinator.test.js
@@ -4,7 +4,6 @@ describe('StateResyncCoordinator', () => {
     let settings;
     let commandQueue;
     let haDiscovery;
-    let securityEventHandler;
     let initializationService;
     let logger;
     let coordinator;
@@ -19,15 +18,22 @@ describe('StateResyncCoordinator', () => {
         };
         commandQueue = { add: jest.fn() };
         haDiscovery = { republishDiscoveryConfigs: jest.fn().mockReturnValue(3) };
-        securityEventHandler = { requestStatusSync: jest.fn() };
-        initializationService = { _resolveGetallNetworks: jest.fn().mockReturnValue(['254/56', '254/203']) };
+        // Stand-in for BridgeInitializationService, which owns both the getall
+        // command syntax and the "which networks does security sync" rule.
+        initializationService = {
+            _resolveGetallNetworks: () => ['254/56', '254/203'],
+            sendGetallLevels: jest.fn((netapps, options) => {
+                const pairs = netapps || ['254/56', '254/203'];
+                for (const netapp of pairs) commandQueue.add(`GET //TEST/${netapp}/* level\n`, options);
+                return pairs;
+            }),
+            sendSecurityStatusRequests: jest.fn()
+        };
         logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn() };
         coordinator = new StateResyncCoordinator({
             settings,
-            commandQueue,
             logger,
             getHaDiscovery: () => haDiscovery,
-            getSecurityEventHandler: () => securityEventHandler,
             initializationService
         });
     });
@@ -41,8 +47,8 @@ describe('StateResyncCoordinator', () => {
         it('queues a getall per configured net/app', () => {
             coordinator.requestResync('ha-birth');
             jest.advanceTimersByTime(5000);
-            expect(commandQueue.add).toHaveBeenCalledWith('GET //TEST/254/56/* level\n');
-            expect(commandQueue.add).toHaveBeenCalledWith('GET //TEST/254/203/* level\n');
+            expect(commandQueue.add).toHaveBeenCalledWith('GET //TEST/254/56/* level\n', { priority: 'bulk' });
+            expect(commandQueue.add).toHaveBeenCalledWith('GET //TEST/254/203/* level\n', { priority: 'bulk' });
         });
 
         it('does nothing until the debounce elapses', () => {
@@ -84,21 +90,21 @@ describe('StateResyncCoordinator', () => {
         });
 
         it('runs for a broker reconnect, which may have dropped them', () => {
-            coordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+            coordinator.requestResync('mqtt-reconnect');
             jest.advanceTimersByTime(5000);
             expect(haDiscovery.republishDiscoveryConfigs).toHaveBeenCalledTimes(1);
         });
 
         it('stays requested when a collapsed trigger asked for it', () => {
             coordinator.requestResync('ha-birth');
-            coordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+            coordinator.requestResync('mqtt-reconnect');
             jest.advanceTimersByTime(5000);
             expect(haDiscovery.republishDiscoveryConfigs).toHaveBeenCalledTimes(1);
         });
 
         it('survives a missing haDiscovery', () => {
             haDiscovery = null;
-            coordinator.requestResync('mqtt-reconnect', { republishDiscovery: true });
+            coordinator.requestResync('mqtt-reconnect');
             expect(() => jest.advanceTimersByTime(5000)).not.toThrow();
             expect(commandQueue.add).toHaveBeenCalled();
         });
@@ -108,23 +114,23 @@ describe('StateResyncCoordinator', () => {
         // Security panels don't answer lighting-style getall (spec §5.9), so
         // without this the new zone sensors would go stale across exactly the
         // restart this coordinator exists to fix.
-        it('requests a security status sync per distinct network', () => {
+        it('delegates the security sync to the init service, which knows the right networks', () => {
             coordinator.requestResync('ha-birth');
             jest.advanceTimersByTime(5000);
-            expect(securityEventHandler.requestStatusSync).toHaveBeenCalledTimes(1);
-            expect(securityEventHandler.requestStatusSync).toHaveBeenCalledWith('254', 'resync');
+            expect(initializationService.sendSecurityStatusRequests).toHaveBeenCalledWith('resync');
         });
 
-        it('survives a missing security handler', () => {
-            securityEventHandler = null;
+        it('still syncs security when no getall networks are configured', () => {
+            initializationService.sendGetallLevels = jest.fn().mockReturnValue([]);
             coordinator.requestResync('ha-birth');
-            expect(() => jest.advanceTimersByTime(5000)).not.toThrow();
+            jest.advanceTimersByTime(5000);
+            expect(initializationService.sendSecurityStatusRequests).toHaveBeenCalledWith('resync');
         });
     });
 
     describe('nothing to do', () => {
         it('logs at debug and sends nothing when no networks are configured', () => {
-            initializationService._resolveGetallNetworks.mockReturnValue([]);
+            initializationService.sendGetallLevels = jest.fn().mockReturnValue([]);
             coordinator.requestResync('ha-birth');
             jest.advanceTimersByTime(5000);
             expect(commandQueue.add).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes the two remaining alpha-feedback items on #42 and fixes #44.

## Security panel trouble sensors (#42)

Seven panel-wide conditions the panel was already reporting but the bridge discarded as "verb pending support" at DEBUG: mains, battery, tamper, panic, phone line, arm failure and fire.

They become `binary_sensor`s on a single shared **C-Bus Security Panel** device with `entity_category: diagnostic`, so they group under Diagnostics rather than landing on dashboards. State lives at `cbus/read/{net}/{app}/panel/{condition}/state` — the non-numeric `panel` segment cannot be confused with a zone number.

**Seeding matters here** because the panel only reports transitions and offers no way to query mains/battery/line/arm-fail/fire. On first traffic all seven are seeded: tamper and panic from the `status_report_1` prefix bytes (the only authoritative source), the rest assumed healthy. A stale OFF self-corrects on the next transition or disarm; leaving them Unknown would strand them that way for months on a healthy panel — which is the complaint behind #44.

**Three verbs are inferred, not captured.** The logs show `low_battery_corrected`, `tamper_off` and `panic_activated` but never their opposites, so `low_battery`, `tamper_on` and `panic_off`/`panic_cleared` are inferred from the convention of the confirmed pairs. Handling a verb that never arrives costs nothing, and panic recovers via the disarm-derived clear regardless.

No new config option — this rides the existing security app id plus `ha_discovery_enabled`, so `config.yaml` and the 17 translation files are untouched.

## Live Events descriptions (#42)

An arm sequence rendered as a column of `0 (0%)` / `255 (100%)`. The handler already built the right sentence for the INFO log; it just never reached the SSE feed. Now reads "Zone unsealed", "Zone 13 bypassed", "System armed (Day mode)". Lighting rows are unchanged.

## Restart state resync (#44)

`retainreads` defaults off and getall only ran at startup, so state was published once per bridge session. Neither restart that matters looks like a bridge restart:

- **HA restarting** leaves the add-on running and doesn't drop our broker connection, so nothing republished. Entities sat unknown until the next physical C-Bus event — the two-lightning-bolt icon that snaps to a real one the first time you touch the switch.
- **The broker restarting** without persistence loses the retained discovery configs too, so entities vanished entirely.

Both now trigger a resync through one debounce. HA's birth message covers the first; a distinguished mqtt reconnect covers the second and also replays the discovery configs.

Two things needed care: security panels don't answer lighting-style getall (spec 5.9), so the coordinator requests a status sync separately or the new zone sensors would go stale across exactly the restart this fixes. And `requestStatusSync` deduped per session, so the resync trigger is exempt — HA can restart many times in one session.

`GETSTATE //NET levels` was suggested on the issue but deferred: its reply lines carry an OID token where the current parser expects a dash, so it needs new parsing for no gain here.

## Notes

Includes a cleanup pass from a four-angle review. The main item: one condition's wire verbs, HA metadata and log wording now live in a single record in `src/securityPanelConditions.js` instead of seven tables across four modules, where a partial eighth addition would have failed silently.

2300 tests pass, lint and typecheck clean, both add-on validators pass, versions in sync at 1.21.0.