### PR TITLE
fix(ci): make the test suite order-independent and the integration wait diagnosable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,15 +93,21 @@ jobs:
           homeassistant-addon/rootfs/usr/lib/cgateweb/*.sh
 
     - name: actionlint
+      # Retry the release download: a 5xx or reset from the GitHub release CDN
+      # has nothing to do with the code under test, and without --retry it fails
+      # a required check. --retry-all-errors is needed because -f turns an HTTP
+      # error into exit 22, which plain --retry does not consider retryable.
       run: |
-        curl -fsSL -o /tmp/actionlint.tar.gz \
+        curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+          --connect-timeout 30 --max-time 300 -o /tmp/actionlint.tar.gz \
           "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
         tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
         /tmp/actionlint -color
 
     - name: hadolint
       run: |
-        curl -fsSL -o /tmp/hadolint \
+        curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+          --connect-timeout 30 --max-time 300 -o /tmp/hadolint \
           "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64"
         chmod +x /tmp/hadolint
         /tmp/hadolint homeassistant-addon/Dockerfile test-env/Dockerfile
@@ -494,7 +500,9 @@ jobs:
         CGATE_UPLOAD_TEST_URL: ${{ vars.CGATE_UPLOAD_TEST_URL }}
       run: |
         mkdir -p test-env/volumes/share/cgate
-        curl -fSL --max-time 600 --connect-timeout 30 -o test-env/volumes/share/cgate/cgate-hosted.zip "$CGATE_UPLOAD_TEST_URL"
+        curl -fSL --retry 3 --retry-all-errors --retry-delay 10 \
+          --max-time 600 --connect-timeout 30 \
+          -o test-env/volumes/share/cgate/cgate-hosted.zip "$CGATE_UPLOAD_TEST_URL"
 
     - name: Set up managed-upload test options
       run: cp test-env/options-managed-upload.json test-env/active-options.json

--- a/.github/workflows/hacs-distribution.yml
+++ b/.github/workflows/hacs-distribution.yml
@@ -81,14 +81,18 @@ jobs:
           homeassistant-addon/rootfs/etc/services.d/*/run \
           homeassistant-addon/rootfs/etc/services.d/*/finish
     - name: actionlint
+      # Same retry rationale as ci.yml: a transient GitHub release CDN blip must
+      # not be the reason a tagged release fails to publish.
       run: |
-        curl -fsSL -o /tmp/actionlint.tar.gz \
+        curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+          --connect-timeout 30 --max-time 300 -o /tmp/actionlint.tar.gz \
           "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
         tar -xzf /tmp/actionlint.tar.gz -C /tmp actionlint
         /tmp/actionlint -color
     - name: hadolint
       run: |
-        curl -fsSL -o /tmp/hadolint \
+        curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+          --connect-timeout 30 --max-time 300 -o /tmp/hadolint \
           "https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64"
         chmod +x /tmp/hadolint
         /tmp/hadolint homeassistant-addon/Dockerfile test-env/Dockerfile
@@ -225,7 +229,9 @@ jobs:
         CGATE_UPLOAD_TEST_URL: ${{ vars.CGATE_UPLOAD_TEST_URL }}
       run: |
         mkdir -p test-env/volumes/share/cgate
-        curl -fSL --max-time 600 --connect-timeout 30 -o test-env/volumes/share/cgate/cgate-hosted.zip "$CGATE_UPLOAD_TEST_URL"
+        curl -fSL --retry 3 --retry-all-errors --retry-delay 10 \
+          --max-time 600 --connect-timeout 30 \
+          -o test-env/volumes/share/cgate/cgate-hosted.zip "$CGATE_UPLOAD_TEST_URL"
     - name: Set up managed-upload test options
       run: cp test-env/options-managed-upload.json test-env/active-options.json
     - name: Run integration test (upload mode - hosted C-Gate)

--- a/test-env/integration-test.js
+++ b/test-env/integration-test.js
@@ -37,7 +37,20 @@ const mqtt = require('../node_modules/mqtt');
 const TEST_ENV_DIR   = path.resolve(__dirname);
 const CGATE_JAR      = path.join(TEST_ENV_DIR, 'volumes/data/cgate/cgate.jar');
 const MQTT_URL       = 'mqtt://localhost:1883';
-const READY_TIMEOUT  = Number(process.env.CGATEWEB_E2E_READY_TIMEOUT_MS) || 3 * 60 * 1000;   // 3 min — covers first-time C-Gate download
+// Readiness is now measured from the moment C-Gate is installed, not from
+// container start: the install phase gets its own progress-based wait below.
+// Folding the two together meant one flat deadline had to cover a 57MB download
+// from a third party AND the thing the test is actually about.
+const READY_TIMEOUT  = Number(process.env.CGATEWEB_E2E_READY_TIMEOUT_MS) || 3 * 60 * 1000;
+// No progress at all for this long means the install is wedged, not slow.
+const INSTALL_STALL_MS = Number(process.env.CGATEWEB_E2E_INSTALL_STALL_MS) || 2 * 60 * 1000;
+// Absolute ceiling so a pathologically slow CDN cannot burn the job's timeout
+// budget. cgate-install.sh allows curl 600s per attempt and retries 3 times, so
+// this is deliberately shorter than the container's own worst case -- but it is
+// only reached when the download is genuinely still making progress.
+const INSTALL_MAX_MS = Number(process.env.CGATEWEB_E2E_INSTALL_TIMEOUT_MS) || 8 * 60 * 1000;
+// C-Gate binds its command port within a couple of seconds of the JVM starting.
+const CGATE_LISTEN_TIMEOUT_MS = Number(process.env.CGATEWEB_E2E_CGATE_LISTEN_TIMEOUT_MS) || 90 * 1000;
 const STABLE_WINDOW  = 10 * 1000;        // 10 s stability check after ready
 
 const args           = new Set(process.argv.slice(2));
@@ -91,24 +104,216 @@ function composeDown() {
 }
 
 /**
- * Print the tail of each compose container's logs. Called when the run fails
- * so CI output shows what the addon actually did (C-Gate install, bridge
- * startup) — a bare readiness timeout otherwise leaves nothing to diagnose.
- * Uses `ps -a` because a failed cont-init can leave the addon container
- * stopped before we get here.
+ * Name of the compose container for a service, or null. `ps -a` because a
+ * failed cont-init can leave the container stopped.
+ *
+ * Sorted by creation and taking the newest: a previous run that was torn down
+ * uncleanly leaves an exited container matching the same name filter, and
+ * picking that one made the install wait below report "the addon container is
+ * exited" one second into a perfectly healthy run.
+ */
+function containerFor(service, { includeStopped = true } = {}) {
+    const args = ['ps'];
+    if (includeStopped) args.push('-a');
+    args.push('--sort', 'created', '--format', '{{.Names}}', '--filter', `name=${service}`);
+    const ps = spawnSync('podman', args, { encoding: 'utf8' });
+    const names = (ps.stdout || '').trim().split('\n').filter(Boolean);
+    return names.length ? names[names.length - 1] : null;
+}
+
+/**
+ * Print each compose container's logs. Called when the run fails so CI output
+ * shows what the addon actually did — a bare readiness timeout otherwise leaves
+ * nothing to diagnose.
+ *
+ * The addon gets its head printed as well as its tail. The C-Gate install runs
+ * in cont-init, i.e. in the container's first few seconds, and the bridge's
+ * reconnect loop then emits several lines a second; on a failed run the tail
+ * was 300 lines of "Connecting to C-Gate command port" and the install output —
+ * the only thing that could say whether the download succeeded — had scrolled
+ * off. That is why the last readiness timeout in CI was undiagnosable.
  */
 function dumpContainerLogs() {
     const services = [['addon', 300], ['supervisor', 100], ['mqtt', 100]];
     for (const [svc, tail] of services) {
-        const ps = spawnSync('podman', ['ps', '-a', '--format', '{{.Names}}', '--filter', `name=${svc}`], {
-            encoding: 'utf8',
-        });
-        const container = (ps.stdout || '').trim().split('\n').filter(Boolean)[0];
+        const container = containerFor(svc);
         if (!container) continue;
+
+        if (svc === 'addon') {
+            const head = spawnSync('podman', ['logs', container], { encoding: 'utf8' });
+            const headOut = `${head.stdout || ''}${head.stderr || ''}`.split('\n').slice(0, 200).join('\n').trimEnd();
+            log(`\n${BOLD}── container logs: ${container} (first 200 lines — cont-init / C-Gate install) ──${RESET}`);
+            log(headOut || '(no output)');
+        }
+
         log(`\n${BOLD}── container logs: ${container} (last ${tail} lines) ──${RESET}`);
         const res = spawnSync('podman', ['logs', '--tail', String(tail), container], { encoding: 'utf8' });
         const out = `${res.stdout || ''}${res.stderr || ''}`.trimEnd();
         log(out || '(no output)');
+    }
+}
+
+/**
+ * A cheap fingerprint of how far the managed C-Gate install has got. Any change
+ * between polls counts as progress, which is what lets the wait below tell
+ * "slow" apart from "wedged" without putting a stopwatch on someone else's CDN.
+ *
+ * Three signals, because no single one covers the whole install: the extracted
+ * jar (the finish line, visible on the host via the /data bind mount), the size
+ * of the part-downloaded zip (only visible inside the container — it lands in a
+ * mktemp dir under /tmp, which is not mounted), and the container's log length
+ * (covers unzip, copy and C-Gate startup, where neither of the other two moves).
+ */
+function installProgress() {
+    const container = containerFor('addon');
+    if (!container) return { alive: false, status: 'absent', fingerprint: 'absent' };
+
+    const inspect = spawnSync('podman', ['inspect', '-f', '{{.State.Status}}', container], { encoding: 'utf8' });
+    const status = (inspect.stdout || '').trim() || 'unknown';
+
+    let zipBytes = 0;
+    if (status === 'running') {
+        const stat = spawnSync(
+            'podman',
+            ['exec', container, 'sh', '-c', 'stat -c%s /tmp/cgate-install.*/cgate-download.zip 2>/dev/null | head -1'],
+            { encoding: 'utf8' }
+        );
+        zipBytes = parseInt((stat.stdout || '').trim(), 10) || 0;
+    }
+
+    const logs = spawnSync('podman', ['logs', container], { encoding: 'utf8' });
+    const logLines = `${logs.stdout || ''}${logs.stderr || ''}`.split('\n').length;
+
+    const jar = fs.existsSync(CGATE_JAR);
+    return {
+        alive: status === 'running',
+        status,
+        jar,
+        zipBytes,
+        logLines,
+        fingerprint: `${jar ? 1 : 0}:${zipBytes}:${logLines}`,
+    };
+}
+
+/**
+ * Wait for the managed C-Gate install to finish, i.e. for cgate.jar to appear
+ * in the bind-mounted data volume.
+ *
+ * This used to be folded into the MQTT readiness wait: a single 180s deadline
+ * covering a 57MB download from Schneider, a checksum, an unzip, a JVM start
+ * *and* the bridge connecting. cgate-install.sh gives curl 600s per attempt and
+ * retries three times, so on a runner Schneider is serving slowly the test
+ * declared failure while the container was still doing exactly what it was told
+ * to. Both outcomes then read as the same line in the log.
+ *
+ * The fix is not a bigger number. It is to wait on the condition, give up when
+ * the container stops making progress (or exits), and say which phase failed.
+ */
+async function waitForCgateInstalled({ stallMs = INSTALL_STALL_MS, maxMs = INSTALL_MAX_MS } = {}) {
+    const startedAt = Date.now();
+    let lastFingerprint = null;
+    let lastProgressAt = startedAt;
+    let lastReport = 0;
+    let deadPolls = 0;
+
+    for (;;) {
+        const p = installProgress();
+        const elapsedMs = Date.now() - startedAt;
+
+        if (p.jar) return { installed: true, elapsedMs };
+
+        // Two consecutive readings before calling it dead: podman reports a
+        // container that is mid-create as absent, and a one-poll blip should
+        // not end the run.
+        if (p.status === 'exited' || p.status === 'absent') {
+            deadPolls += 1;
+            if (deadPolls >= 2) {
+                return {
+                    installed: false,
+                    elapsedMs,
+                    reason: `the addon container is ${p.status} after ${Math.round(elapsedMs / 1000)}s — cont-init failed, see the container log below`,
+                };
+            }
+        } else {
+            deadPolls = 0;
+        }
+
+        if (p.fingerprint !== lastFingerprint) {
+            lastFingerprint = p.fingerprint;
+            lastProgressAt = Date.now();
+        }
+
+        const stalledMs = Date.now() - lastProgressAt;
+        if (stalledMs >= stallMs) {
+            return {
+                installed: false,
+                elapsedMs,
+                reason: `no install progress for ${Math.round(stalledMs / 1000)}s (downloaded ${p.zipBytes} bytes, container ${p.status}) — the install is wedged, not merely slow`,
+            };
+        }
+
+        if (elapsedMs >= maxMs) {
+            return {
+                installed: false,
+                elapsedMs,
+                reason: `still installing after ${Math.round(elapsedMs / 1000)}s (downloaded ${p.zipBytes} bytes) — still making progress, but past the ${Math.round(maxMs / 1000)}s ceiling`,
+            };
+        }
+
+        // One line every 30s so a slow download looks like a slow download in
+        // the CI log rather than three minutes of silence.
+        if (elapsedMs - lastReport >= 30000) {
+            lastReport = elapsedMs;
+            info(`still installing (${Math.round(elapsedMs / 1000)}s, ${p.zipBytes} bytes downloaded, container ${p.status})`);
+        }
+
+        await new Promise(r => setTimeout(r, 2000));
+    }
+}
+
+/**
+ * Is C-Gate accepting TCP connections on its command port? Asked from inside the
+ * container because access.txt only permits 127.0.0.1 and the port is not
+ * published to the host.
+ */
+function cgatePortListening(port = 20023) {
+    const container = containerFor('addon', { includeStopped: false });
+    if (!container) return false;
+    const res = spawnSync('podman', ['exec', container, 'nc', '-z', '127.0.0.1', String(port)], {
+        encoding: 'utf8',
+    });
+    return res.status === 0;
+}
+
+/**
+ * Wait for C-Gate itself to bind its command port.
+ *
+ * This phase exists because of a CI failure that produced nothing but
+ * "Bridge did not become ready within 180s". The bridge was in fact running and
+ * retrying against ECONNREFUSED for the whole three minutes, which means
+ * cont-init had completed and cgate.jar was on disk -- the download was fine and
+ * the JVM was the problem. Nothing in the output said so, and the C-Gate service
+ * output that would have explained it had already scrolled out of the log tail.
+ *
+ * Splitting it out means the next occurrence names the phase: C-Gate never bound
+ * the port, or it bound it and the bridge still did not come up. Normal is under
+ * two seconds, so the ceiling here is generous rather than load-bearing.
+ */
+async function waitForCgateListening({ timeoutMs = CGATE_LISTEN_TIMEOUT_MS } = {}) {
+    const startedAt = Date.now();
+    for (;;) {
+        if (cgatePortListening()) return { listening: true, elapsedMs: Date.now() - startedAt };
+
+        const elapsedMs = Date.now() - startedAt;
+        if (elapsedMs >= timeoutMs) {
+            const p = installProgress();
+            return {
+                listening: false,
+                elapsedMs,
+                reason: `C-Gate is installed but never accepted a connection on port 20023 within ${Math.round(timeoutMs / 1000)}s (addon container ${p.status}) — the JVM did not start or died on startup, see the C-Gate service lines in the container log below`,
+            };
+        }
+        await new Promise(r => setTimeout(r, 1000));
     }
 }
 
@@ -120,10 +325,7 @@ function dumpContainerLogs() {
  * which the MQTT surface alone can't prove without live C-Bus hardware.
  */
 function probeCgate(commands, port = 20023) {
-    const ps = spawnSync('podman', ['ps', '--format', '{{.Names}}', '--filter', 'name=addon'], {
-        encoding: 'utf8',
-    });
-    const container = (ps.stdout || '').trim().split('\n').filter(Boolean)[0];
+    const container = containerFor('addon', { includeStopped: false });
     if (!container) return { ok: false, output: '', error: 'addon container not found' };
 
     // Single-quote each command for bash, escaping any embedded single quotes
@@ -153,10 +355,7 @@ function probeCgate(commands, port = 20023) {
  * Returns { ok, status, body, error }.
  */
 function curlInAddon(urlPath, { method = 'GET', headers = {}, body = null } = {}) {
-    const ps = spawnSync('podman', ['ps', '--format', '{{.Names}}', '--filter', 'name=addon'], {
-        encoding: 'utf8',
-    });
-    const container = (ps.stdout || '').trim().split('\n').filter(Boolean)[0];
+    const container = containerFor('addon', { includeStopped: false });
     if (!container) return { ok: false, status: 0, body: '', error: 'addon container not found' };
 
     const args = ['exec', '-i', container, 'curl', '-s', '-w', '\n%{http_code}', '-X', method];
@@ -355,7 +554,20 @@ async function runTests() {
         info('C-Gate already installed — skipping download wait');
     } else {
         info('C-Gate not yet installed — waiting for download + install...');
+        const install = await waitForCgateInstalled();
+        if (!install.installed) {
+            fail(`C-Gate install did not complete: ${install.reason}`);
+            return { passed, failed: failed + 1 };
+        }
+        info(`C-Gate installed after ${Math.round(install.elapsedMs / 1000)}s`);
     }
+
+    const listening = await waitForCgateListening();
+    if (!listening.listening) {
+        fail(listening.reason);
+        return { passed, failed: failed + 1 };
+    }
+    info(`C-Gate accepting connections on 20023 after ${Math.round(listening.elapsedMs / 1000)}s`);
 
     // Live-C-Bus assertions (entity counts, discovery_status=ok, empty retry
     // queue) require a *synced* C-Bus network — i.e. real hardware or a
@@ -390,7 +602,15 @@ async function runTests() {
         msgs = await waitForMqtt(READINESS_TOPICS, isReady, READY_TIMEOUT);
         info(`Bridge reached ready state`);
     } catch (err) {
-        fail(`Bridge did not become ready within ${READY_TIMEOUT / 1000}s: ${err.message}`);
+        // Reaching here means C-Gate is installed AND was accepting connections,
+        // so the failure is the bridge's, not the download's or the JVM's. Say
+        // whether C-Gate is *still* listening: if it is not, it died after
+        // startup, which is a different bug from a bridge that never connects.
+        const stillListening = cgatePortListening();
+        fail(
+            `C-Gate installed and reached its command port, but the bridge did not become ready within ${READY_TIMEOUT / 1000}s ` +
+            `(C-Gate ${stillListening ? 'is still listening — the bridge is at fault' : 'has since stopped listening — C-Gate died after startup'}): ${err.message}`
+        );
         return { passed, failed: failed + 1 };
     }
 

--- a/tests/cgateWebBridge.test.js
+++ b/tests/cgateWebBridge.test.js
@@ -5,8 +5,12 @@ const { defaultSettings } = require('../index.js');
 const EventEmitter = require('events');
 
 // --- Mock CgateConnectionPool ---
+// One emitter shared by every test in this file, because jest.mock hands the
+// same instance to every `new CgateConnectionPool(...)`. The afterEach below
+// detaches its listeners; without that, each bridge built in beforeEach leaves
+// its subscriptions attached and events fired by a later test also run every
+// earlier test's handlers against a half-torn-down bridge.
 const mockConnectionPool = new EventEmitter();
-mockConnectionPool.setMaxListeners(100); // Prevent memory leak warnings
 mockConnectionPool.start = jest.fn().mockImplementation(async () => {
     mockConnectionPool.isStarted = true;
     mockConnectionPool.healthyConnections = { size: 3 };
@@ -173,7 +177,12 @@ describe('CgateWebBridge', () => {
         
         // Run any pending setImmediate callbacks before clearing
         await new Promise(resolve => setImmediate(resolve));
-        
+
+        // The pool mock is module-scoped and outlives every bridge, so its
+        // listeners have to be dropped explicitly (bridge.stop() would do it,
+        // but the teardown above deliberately stops short of a full stop()).
+        mockConnectionPool.removeAllListeners();
+
         jest.clearAllTimers();
         mockConsoleWarn.mockClear();
         mockConsoleError.mockClear();

--- a/tests/config/addonIntegration.test.js
+++ b/tests/config/addonIntegration.test.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const yaml = require('yaml');
 
@@ -155,11 +156,25 @@ describe('Addon Configuration Integration', () => {
     });
 
     describe('ConfigLoader addon options mapping', () => {
+        // A private temp dir per run, not a fixed .tmp-test-options.json in the
+        // repo root: the old shared name meant two concurrent jest runs over the
+        // same checkout clobbered each other's options file, and a crash between
+        // write and unlink left an untracked, un-ignored file behind.
+        let tmpDir;
+
+        beforeEach(() => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgateweb-addon-options-'));
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
         test('should reject config.yaml defaults with empty cgate_host in remote mode', () => {
             const ConfigLoader = require('../../src/config/ConfigLoader');
 
             const optionsJson = JSON.stringify(configYaml.options);
-            const tmpPath = path.join(__dirname, '../../.tmp-test-options.json');
+            const tmpPath = path.join(tmpDir, 'options.json');
 
             fs.writeFileSync(tmpPath, optionsJson);
 
@@ -186,7 +201,7 @@ describe('Addon Configuration Integration', () => {
 
             const optionsWithHost = { ...configYaml.options, cgate_host: '192.168.1.100' };
             const optionsJson = JSON.stringify(optionsWithHost);
-            const tmpPath = path.join(__dirname, '../../.tmp-test-options.json');
+            const tmpPath = path.join(tmpDir, 'options.json');
 
             fs.writeFileSync(tmpPath, optionsJson);
 

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -1,5 +1,14 @@
 const ORIGINAL_ENV = { ...process.env };
 
+// main() attaches shutdown/crash handlers to the *global* process object.
+// jest.resetModules() throws away the module registry but not those listeners,
+// so every main() call in this file left another set behind: past ten the run
+// printed MaxListenersExceededWarning, and once afterEach restored the real
+// process.exit those stale uncaughtException/unhandledRejection handlers were
+// live wires -- one stray rejection later in the file would have called the
+// real process.exit(1) and taken the Jest worker down mid-run.
+const PROCESS_EVENTS = ['SIGTERM', 'SIGINT', 'SIGUSR1', 'uncaughtException', 'unhandledRejection'];
+
 function loadIndexWithMocks({
     loadedConfig = { cbusip: '10.0.0.10', mqtt: 'broker:1883', _environment: { type: 'standalone' } },
     loadError = null,
@@ -74,8 +83,12 @@ describe('index.js', () => {
     let _exitSpy;
     let logSpy;
     let errorSpy;
+    let processListenersBefore;
 
     beforeEach(() => {
+        processListenersBefore = new Map(
+            PROCESS_EVENTS.map((event) => [event, process.listeners(event)])
+        );
         jest.resetModules();
         process.env = { ...ORIGINAL_ENV };
         delete process.env.ALLOW_DEFAULT_FALLBACK;
@@ -96,6 +109,16 @@ describe('index.js', () => {
     });
 
     afterEach(() => {
+        // Detach anything main() bolted onto the shared process object, so the
+        // next test starts from the listener set this one inherited.
+        for (const event of PROCESS_EVENTS) {
+            const inherited = processListenersBefore.get(event);
+            for (const listener of process.listeners(event)) {
+                if (!inherited.includes(listener)) {
+                    process.removeListener(event, listener);
+                }
+            }
+        }
         process.env = { ...ORIGINAL_ENV };
         jest.restoreAllMocks();
     });

--- a/tests/install-service.test.js
+++ b/tests/install-service.test.js
@@ -23,7 +23,12 @@ describe('install-service.js', () => {
 
     beforeEach(() => {
         jest.resetModules();
-        jest.clearAllMocks();
+        // resetAllMocks, not clearAllMocks: clearAllMocks only wipes recorded
+        // calls, it leaves mockImplementation/mockReturnValue in place. The
+        // "writing service file fails" test installs a throwing writeFileSync
+        // that nothing below re-stubs, so under clearAllMocks it survives into
+        // whichever test runs next and makes the happy-path installs exit(1).
+        jest.resetAllMocks();
 
         exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
             throw new Error(`process.exit:${code}`);

--- a/tests/throttledQueue.test.js
+++ b/tests/throttledQueue.test.js
@@ -3,10 +3,7 @@
 
 const ThrottledQueue = require('../src/throttledQueue');
 
-// --- Tests --- 
-
-// Use Jest's fake timers
-jest.useFakeTimers();
+// --- Tests ---
 
 describe('ThrottledQueue', () => {
     let mockProcessFn;
@@ -14,11 +11,22 @@ describe('ThrottledQueue', () => {
     const intervalMs = 100;
 
     beforeEach(() => {
+        // Fake timers are installed per test rather than once at module scope:
+        // a single module-scope jest.useFakeTimers() can be undone by any test
+        // that switches back to real timers, and whether that has happened yet
+        // depends on execution order. Installing them here makes every test
+        // start from the same timer state no matter what ran before it.
+        jest.useFakeTimers();
         // Reset mocks and queue before each test
         mockProcessFn = jest.fn();
         queue = new ThrottledQueue(mockProcessFn, intervalMs);
         // Clear any pending timers
         jest.clearAllTimers();
+    });
+
+    afterEach(() => {
+        queue?.clear?.();
+        jest.useRealTimers();
     });
 
     it('should process the first item immediately when added', () => {
@@ -203,7 +211,6 @@ describe('ThrottledQueue', () => {
         });
 
         it('should drop oldest items when queue is full', () => {
-            jest.useFakeTimers();
             const processed = [];
             const queue = new ThrottledQueue(
                 (item) => processed.push(item),
@@ -229,12 +236,11 @@ describe('ThrottledQueue', () => {
             
             expect(queue.droppedCount).toBe(1);
             expect(queue.length).toBe(3);
-            
-            jest.useRealTimers();
+
+            queue.clear();
         });
 
         it('should allow unlimited queue when maxSize is 0', () => {
-            jest.useFakeTimers();
             const queue = new ThrottledQueue(jest.fn(), 100, 'Test', { maxSize: 0 });
             
             for (let i = 0; i < 5000; i++) {
@@ -244,13 +250,11 @@ describe('ThrottledQueue', () => {
             expect(queue.droppedCount).toBe(0);
             // 1 processed immediately, 4999 in queue
             expect(queue.length).toBe(4999);
-            
+
             queue.clear();
-            jest.useRealTimers();
         });
 
         it('should track total dropped count', () => {
-            jest.useFakeTimers();
             const queue = new ThrottledQueue(jest.fn(), 100, 'Test', { maxSize: 2 });
             
             // Fill queue: first item processed immediately
@@ -262,22 +266,12 @@ describe('ThrottledQueue', () => {
             queue.add('f'); // drop d, queue: [e, f]
             
             expect(queue.droppedCount).toBe(3);
-            
+
             queue.clear();
-            jest.useRealTimers();
         });
     });
 
     describe('priority and processing gate', () => {
-        beforeEach(() => {
-            jest.useFakeTimers();
-            jest.clearAllTimers();
-        });
-
-        afterEach(() => {
-            jest.useFakeTimers();
-        });
-
         it('should process higher-priority items before lower-priority ones', () => {
             const processed = [];
             const queue = new ThrottledQueue(

--- a/tests/uninstall-service.test.js
+++ b/tests/uninstall-service.test.js
@@ -19,7 +19,10 @@ describe('uninstall-service.js', () => {
 
     beforeEach(() => {
         jest.resetModules();
-        jest.clearAllMocks();
+        // Same reasoning as install-service.test.js: clearAllMocks leaves
+        // per-test mockImplementations installed, so a stubbed fs/execSync
+        // behaviour would silently carry into the next test.
+        jest.resetAllMocks();
 
         exitSpy = jest.spyOn(process, 'exit').mockImplementation((code) => {
             throw new Error(`process.exit:${code}`);

--- a/tests/webServer.test.js
+++ b/tests/webServer.test.js
@@ -1764,6 +1764,32 @@ describe('WebServer', () => {
             });
         }
 
+        /**
+         * Poll until `predicate()` is truthy, or fail with a message naming what
+         * we were waiting for.
+         *
+         * These tests drive a real HTTP server over a real socket, so the events
+         * they assert on (the server noticing a client hang-up, a chunk landing
+         * in the client's buffer) arrive whenever the kernel and the event loop
+         * get round to them. A fixed `setTimeout(..., 30)` encodes one machine's
+         * timing as a correctness requirement: it passes on a laptop and becomes
+         * a coin flip on a loaded CI runner. Polling asserts the same thing but
+         * finishes as soon as it is true and only gives up after a margin no
+         * healthy run will ever need.
+         */
+        async function waitFor(predicate, { label = 'condition', timeoutMs = 5000, intervalMs = 5 } = {}) {
+            const deadline = Date.now() + timeoutMs;
+            for (;;) {
+                if (predicate()) return;
+                if (Date.now() >= deadline) {
+                    throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}`);
+                }
+                await new Promise((r) => setTimeout(r, intervalMs));
+            }
+        }
+
+        const countDataLines = (lines) => lines.filter((l) => l.startsWith('data:')).length;
+
         it('returns 200 with Content-Type text/event-stream', async () => {
             const { res, destroy } = await openSSE(port);
             expect(res.statusCode).toBe(200);
@@ -1809,7 +1835,7 @@ describe('WebServer', () => {
             expect(second.status).toBe(503);
 
             first.destroy();
-            await new Promise((r) => setTimeout(r, 20));
+            await waitFor(() => listeners.size === 0, { label: 'the server to release the first SSE slot' });
             const third = await openSSE(cappedPort);
             expect(third.res.statusCode).toBe(200);
             third.destroy();
@@ -1835,8 +1861,7 @@ describe('WebServer', () => {
             const ssePort = sseServer._server.address().port;
 
             const { lines, destroy } = await openSSE(ssePort);
-            // Give response a tick to flush
-            await new Promise((r) => setTimeout(r, 50));
+            await waitFor(() => countDataLines(lines) >= 1, { label: 'the buffered event to reach the client' });
             destroy();
             await sseServer.close();
 
@@ -1846,7 +1871,7 @@ describe('WebServer', () => {
             expect(parsed).toMatchObject({ ts: 1000, network: '254', app: '56', group: '5' });
         });
 
-        it('SSE client receives new events pushed after connecting', (done) => {
+        it('SSE client receives new events pushed after connecting', async () => {
             const listeners = new Set();
             const mockStream = {
                 subscribe: (fn) => listeners.add(fn),
@@ -1859,38 +1884,41 @@ describe('WebServer', () => {
                 allowUnauthenticatedMutations: true,
                 eventStream: mockStream
             });
-            sseServer.start().then(() => {
-                const ssePort = sseServer._server.address().port;
-                const received = [];
-                const req = http.request(
+            await sseServer.start();
+            const ssePort = sseServer._server.address().port;
+
+            const received = [];
+            const req = await new Promise((resolve, reject) => {
+                const request = http.request(
                     { hostname: '127.0.0.1', port: ssePort, path: '/api/events/stream', method: 'GET' },
                     (res) => {
                         res.on('data', (chunk) => {
                             received.push(...chunk.toString().split('\n').filter(Boolean));
                         });
-
-                        // After connection is open, push a live event
-                        setTimeout(() => {
-                            const liveEvent = { ts: 2000, network: '254', app: '56', group: '10', level: 255, type: 'on' };
-                            for (const fn of listeners) fn(liveEvent);
-
-                            setTimeout(() => {
-                                req.destroy();
-                                sseServer.close().then(() => {
-                                    const dataLines = received.filter((l) => l.startsWith('data:'));
-                                    expect(dataLines.length).toBeGreaterThanOrEqual(1);
-                                    const parsed = JSON.parse(dataLines[dataLines.length - 1].slice('data:'.length).trim());
-                                    expect(parsed).toMatchObject({ ts: 2000, group: '10', level: 255 });
-                                    done();
-                                }).catch(done);
-                            }, 50);
-                        }, 30);
+                        resolve(request);
                     }
                 );
-                req.on('error', (e) => { if (e.code !== 'ECONNRESET') done(e); });
-                req.end();
-            }).catch(done);
-        }, 10000);
+                request.on('error', (e) => { if (e.code !== 'ECONNRESET') reject(e); });
+                request.end();
+            });
+
+            // The response headers arriving does not mean the handler has
+            // finished subscribing, so wait for the subscription itself before
+            // pushing -- an event pushed too early goes to nobody.
+            await waitFor(() => listeners.size === 1, { label: 'the SSE client to subscribe' });
+
+            const liveEvent = { ts: 2000, network: '254', app: '56', group: '10', level: 255, type: 'on' };
+            for (const fn of listeners) fn(liveEvent);
+
+            await waitFor(() => countDataLines(received) >= 1, { label: 'the pushed event to reach the client' });
+
+            req.destroy();
+            await sseServer.close();
+
+            const dataLines = received.filter((l) => l.startsWith('data:'));
+            const parsed = JSON.parse(dataLines[dataLines.length - 1].slice('data:'.length).trim());
+            expect(parsed).toMatchObject({ ts: 2000, group: '10', level: 255 });
+        });
 
         it('disconnect cleans up the listener (no memory leak)', async () => {
             const listeners = new Set();
@@ -1909,13 +1937,11 @@ describe('WebServer', () => {
             const ssePort = sseServer._server.address().port;
 
             const { destroy } = await openSSE(ssePort);
-            await new Promise((r) => setTimeout(r, 30));
-            expect(listeners.size).toBe(1);
+            await waitFor(() => listeners.size === 1, { label: 'the SSE client to subscribe' });
 
             // Disconnect the SSE client
             destroy();
-            await new Promise((r) => setTimeout(r, 80));
-            expect(listeners.size).toBe(0);
+            await waitFor(() => listeners.size === 0, { label: 'the server to unsubscribe the closed client' });
 
             await sseServer.close();
         });
@@ -1973,14 +1999,16 @@ describe('WebServer', () => {
             const req1 = await makeClient(client1Lines);
             const req2 = await makeClient(client2Lines);
 
-            await new Promise((r) => setTimeout(r, 30));
-            expect(listeners.size).toBe(2);
+            await waitFor(() => listeners.size === 2, { label: 'both SSE clients to subscribe' });
 
             // Broadcast an event to all listeners
             const broadcastEvent = { ts: 3000, network: '254', app: '56', group: '7', level: 64, type: 'ramp' };
             for (const fn of listeners) fn(broadcastEvent);
 
-            await new Promise((r) => setTimeout(r, 50));
+            await waitFor(
+                () => countDataLines(client1Lines) >= 1 && countDataLines(client2Lines) >= 1,
+                { label: 'the broadcast to reach both clients' }
+            );
             req1.destroy();
             req2.destroy();
             await sseServer.close();
@@ -1996,7 +2024,7 @@ describe('WebServer', () => {
             expect(p2).toMatchObject({ ts: 3000, group: '7' });
         });
 
-        it('keepalive comment is sent at interval', (done) => {
+        it('keepalive comment is sent at interval', async () => {
             const listeners = new Set();
             const mockStream = {
                 subscribe: (fn) => listeners.add(fn),
@@ -2011,30 +2039,32 @@ describe('WebServer', () => {
                 eventStream: mockStream,
                 _sseKeepaliveMs: 80
             });
-            sseServer.start().then(() => {
-                const ssePort = sseServer._server.address().port;
-                const received = [];
-                const req = http.request(
+            await sseServer.start();
+            const ssePort = sseServer._server.address().port;
+
+            const received = [];
+            const req = await new Promise((resolve, reject) => {
+                const request = http.request(
                     { hostname: '127.0.0.1', port: ssePort, path: '/api/events/stream', method: 'GET' },
                     (res) => {
                         res.on('data', (chunk) => {
                             received.push(chunk.toString());
                         });
-                        // Wait long enough for at least one keepalive
-                        setTimeout(() => {
-                            req.destroy();
-                            sseServer.close().then(() => {
-                                const combined = received.join('');
-                                expect(combined).toContain(': keepalive');
-                                done();
-                            }).catch(done);
-                        }, 200);
+                        resolve(request);
                     }
                 );
-                req.on('error', (e) => { if (e.code !== 'ECONNRESET') done(e); });
-                req.end();
-            }).catch(done);
-        }, 10000);
+                request.on('error', (e) => { if (e.code !== 'ECONNRESET') reject(e); });
+                request.end();
+            });
+
+            // Previously a flat 200ms wait for an 80ms keepalive: two and a half
+            // periods of margin, which a stalled event loop eats easily.
+            await waitFor(() => received.join('').includes(': keepalive'), { label: 'a keepalive comment' });
+
+            req.destroy();
+            await sseServer.close();
+            expect(received.join('')).toContain(': keepalive');
+        });
 
         it('filter/search on client side does not affect SSE server-side streaming', async () => {
             // The SSE endpoint streams all events without filtering;
@@ -2059,7 +2089,7 @@ describe('WebServer', () => {
             const ssePort = sseServer._server.address().port;
 
             const { lines, destroy } = await openSSE(ssePort);
-            await new Promise((r) => setTimeout(r, 50));
+            await waitFor(() => countDataLines(lines) >= 2, { label: 'both buffered events to reach the client' });
             destroy();
             await sseServer.close();
 


### PR DESCRIPTION
Follow-up to #45. That one fixed a third party throttling our runners; this fixes flakiness we own.

## Headline evidence

Randomized test order, full suite, 10 seeds each — measured independently of the change author:

| | failures |
|---|---|
| `master` | **9 / 10** |
| this branch | **0 / 10** |

The suite has been order-dependent for a while. It only looked stable because Jest's default order happened to be benign.

## Order dependence (the real flakes)

**`tests/throttledQueue.test.js`** — module-scope `jest.useFakeTimers()`, but three nested tests called `jest.useRealTimers()` on the way out. Any top-level test running after one of those silently got real timers, so `advanceTimersByTime()` became a no-op. Fake timers are now installed per-test. Was 4/6 seeds failing, now 0/25.

**`tests/install-service.test.js`** — `clearAllMocks` wipes recorded calls but *not* `mockImplementation`. The "writing service file fails" test installs a throwing `writeFileSync` that `beforeEach` never re-stubs, so it leaked forward and turned a later happy-path install into `exit(1)`. Switched to `resetAllMocks`; same latent pattern fixed in `uninstall-service.test.js`. Was 2/6 seeds failing, now 0/25.

A per-file sweep over all 74 test files found only these two.

## Leaked listeners

**`tests/cgateWebBridge.test.js`** — `jest.mock` hands the same module-scoped `EventEmitter` to every `new CgateConnectionPool()`, and `afterEach` never called `bridge.stop()` (the only path that detaches). ~90 bridges' subscriptions accumulated, so any event fired late in the file also ran every earlier test's handlers against a half-torn-down bridge. The `setMaxListeners(100)` that was muting the warning is gone. Full suite now emits **0** `MaxListenersExceededWarning`, down from 6.

**`tests/index.test.js`** — `main()` runs 12 times, each attaching SIGTERM/SIGINT/`uncaughtException`/`unhandledRejection` to the global `process`, which `resetModules()` does not clear. Now snapshotted and detached. Scoped honestly: each test *file* gets its own `process` object, so this is a within-file hazard, not the suite-wide one it first appeared to be.

## Integration readiness wait

The 180s budget spanned container start, a 57MB download, checksum, unzip, JVM start *and* the bridge connecting — so a throttled download, a stalled unzip and a hung JVM all produced the identical `Bridge did not become ready within 180s`.

Now three named phases: **install** (poll for `cgate.jar` with a progress fingerprint over jar presence, part-downloaded zip bytes and log length — no progress for 2 min means wedged, fail immediately; an exited container fails immediately), **listening** (`nc -z` on 20023 inside the container), **ready** (the unchanged MQTT wait, now starting from a demonstrably-up C-Gate).

**`READY_TIMEOUT` is unchanged at 180s.** Measured time-to-ready on successful runs is 4–5s, a 35–45× margin, so the failing case was stalled rather than slow and a bigger number would only have made it slower to fail.

Verified against a deliberately broken cont-init: before, 180s and `Bridge did not become ready` with a tail showing only pool health checks; after, **9s** and `C-Gate install did not complete: the addon container is exited after 9s — cont-init failed`, with the real error in the log head dump.

Also fixes container lookup picking a stale exited container ahead of the live one.

## Smaller

- SSE tests: fixed millisecond sleeps against a real socket replaced with condition polling (also removes ~500ms/run of sleeping). Two `done()` tests swallowed `ECONNRESET`, turning a premature reset into a silent 10s timeout. No failure was reproduced here — structural risk, stated as such.
- Addon options fixture: fixed-name temp file in the repo root → `mkdtempSync` under `os.tmpdir()`.
- `actionlint`, `hadolint` and the hosted C-Gate zip downloads get `--retry --retry-all-errors --retry-delay`. `--retry-all-errors` is required because `-f` reports HTTP errors as exit 22, which plain `--retry` will not retry. Preventive — no historical failure observed.

## Deliberately not fixed

- `--speed-limit`/`--speed-time` in `cgate-install.sh`: the evidence says the failure was not a slow download, so shipped install behaviour was left alone on a hunch. Reasonable standalone hardening.
- `labelLoader.test.js` fs.watch race: re-derived, window is essentially zero-width, 0/10 under 48× load.
- `serialDeviceRecovery.test.js:545` wall-clock assertion with 3s slack, and `cgateProjectSync.test.js` mtime granularity — both flagged, both marginal.

## Verified clean

`--detectOpenHandles` reports nothing. All actions in both workflows already SHA-pinned. No timing thresholds anywhere in the suite. No real network or broker in unit tests.

2300 tests pass, lint and typecheck clean, actionlint clean on both workflows.