### PR TITLE
fix: report managed C-Gate build version

### DIFF
--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
-## [Unreleased]
+## [1.27.0] - 2026-08-21
 
 ### Added
 
 - **Your alarm now tells Home Assistant when an entry delay starts** — someone opened a delay zone while the alarm was armed and the siren follows unless it is disarmed in time. The panel reports this as pending, which is the state worth putting automations on. (#42)
 - **Air conditioning thermostats now show what the plant is doing.** Damper position, plant busy, plant type, fan speed and output, comfort level and humidity state all appear as diagnostic entities. Some are only filled in by plant that reports them, so an empty one means your hardware does not broadcast that field.
 - **The C-Bus network clock can be published as a sensor.** Turn on the new clock option to see the date and time the network is broadcasting, which is how you spot a drifted clock before it moves your schedules. Off by default, and cgateweb never sets the clock.
+
+### Fixed
+
+- **Managed C-Gate installations now show their installed version and build in diagnostics.** Existing installations showing unknown are repaired on their next start. (#66)
 
 ### Changed
 

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.26.0"
+version: "1.27.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/homeassistant-addon/rootfs/etc/cont-init.d/cgate-install.sh
+++ b/homeassistant-addon/rootfs/etc/cont-init.d/cgate-install.sh
@@ -84,6 +84,69 @@ _cgateweb_custom_url_without_sha256() {
     if [[ "${url}" != "${CGATEWEB_DEFAULT_DOWNLOAD_URL}" && -z "${sha}" ]]; then printf '1'; else printf '0'; fi
 }
 
+# Read C-Gate's own build metadata instead of inferring its version from the
+# archive name. Schneider packages BuildInfo.txt beside cgate.jar, and archive
+# names are not stable across download and upload sources.
+_cgateweb_installed_version() {
+    local cgate_dir="$1"
+    local build_info="${cgate_dir}/BuildInfo.txt"
+    local version build
+
+    if [[ ! -r "${build_info}" ]]; then
+        return 1
+    fi
+
+    version=$(awk -F: '
+        tolower($1) ~ /^[[:space:]]*version[[:space:]]*$/ {
+            value = $2
+            sub(/\r$/, "", value)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            print value
+            exit
+        }
+    ' "${build_info}")
+    build=$(awk -F: '
+        tolower($1) ~ /^[[:space:]]*build[[:space:]]*$/ {
+            value = $2
+            sub(/\r$/, "", value)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+            print value
+            exit
+        }
+    ' "${build_info}")
+
+    if [[ -z "${version}" ]]; then
+        return 1
+    fi
+    if [[ -n "${build}" ]]; then
+        printf '%s_%s' "${version}" "${build}"
+    else
+        printf '%s' "${version}"
+    fi
+}
+
+# Keep the marker consumed by bridge diagnostics in sync with BuildInfo.txt.
+# The optional fallback preserves support for packages that omit that file but
+# whose nested archive still carries a version in its filename.
+_cgateweb_record_installed_version() {
+    local cgate_dir="$1"
+    local fallback_version="${2:-}"
+    local detected_version current_version
+
+    detected_version=$(_cgateweb_installed_version "${cgate_dir}" || true)
+    if [[ -z "${detected_version}" ]]; then
+        detected_version="${fallback_version}"
+    fi
+    current_version=$(cat "${cgate_dir}/.version" 2>/dev/null || true)
+
+    if [[ -n "${detected_version}" && "${current_version}" != "${detected_version}" ]]; then
+        printf '%s\n' "${detected_version}" > "${cgate_dir}/.version"
+        bashio::log.info "Recorded C-Gate version: ${detected_version}"
+    elif [[ -z "${current_version}" ]]; then
+        printf 'unknown\n' > "${cgate_dir}/.version"
+    fi
+}
+
 # Standard "what to do now" block for every C-Gate download failure. The most
 # common external cause is Clipsal/Schneider changing the download URL or
 # repackaging the zip (they did on 2026-07-24, breaking every fresh install
@@ -1047,15 +1110,11 @@ fi
 # Restrict permissions on installed files
 chmod -R go-w "${CGATE_DIR}/" 2>/dev/null || true
 
-# Record installed version for diagnostics reporting
-if [[ -n "${CGATE_VERSION}" ]]; then
-    echo "${CGATE_VERSION}" > "${CGATE_DIR}/.version"
-    bashio::log.info "Recorded C-Gate version: ${CGATE_VERSION}"
-else
-    echo "unknown" > "${CGATE_DIR}/.version"
-fi
-
 fi  # end NEED_INSTALL
+
+# Refresh the diagnostic version on every boot so existing managed installs
+# whose marker says "unknown" are repaired without forcing a reinstall.
+_cgateweb_record_installed_version "${CGATE_DIR}" "${CGATE_VERSION:-}"
 
 # Configure access.txt. Runs on every boot, not only when the file is absent,
 # so the grammar fix and any configured external clients reach existing installs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.26.0",
+      "version": "1.27.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",

--- a/tests/cgateInstallScript.test.js
+++ b/tests/cgateInstallScript.test.js
@@ -250,6 +250,63 @@ describeBash('cgate-install.sh helpers', () => {
         });
     });
 
+    describe('_cgateweb_installed_version', () => {
+        function withBuildInfo(contents, callback) {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgate-build-info-'));
+            try {
+                fs.writeFileSync(path.join(dir, 'BuildInfo.txt'), contents);
+                callback(dir);
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        }
+
+        test('reads the version and build from C-Gate metadata', () => {
+            withBuildInfo([
+                'Schneider Electric C-Gate',
+                'Version: 3.3.2',
+                'Build:\t1855',
+                'Date:\t20240524-0410'
+            ].join('\r\n'), (dir) => {
+                const out = runHelperWithArgs('_cgateweb_installed_version', [dir]);
+                expect(out).toBe('3.3.2_1855');
+            });
+        });
+
+        test('returns the version when older metadata has no build field', () => {
+            withBuildInfo('Version: 2.11.12\n', (dir) => {
+                const out = runHelperWithArgs('_cgateweb_installed_version', [dir]);
+                expect(out).toBe('2.11.12');
+            });
+        });
+
+        test('fails when BuildInfo.txt has no version', () => {
+            withBuildInfo('Build: 2287\n', (dir) => {
+                expect(() => runHelperWithArgs('_cgateweb_installed_version', [dir]))
+                    .toThrow();
+            });
+        });
+
+        test('repairs an unknown diagnostics marker from installed metadata', () => {
+            withBuildInfo('Version: 3.7.1\nBuild: 2287\n', (dir) => {
+                const marker = path.join(dir, '.version');
+                fs.writeFileSync(marker, 'unknown\n');
+                runHelperWithArgs('_cgateweb_record_installed_version', [dir]);
+                expect(fs.readFileSync(marker, 'utf8')).toBe('3.7.1_2287\n');
+            });
+        });
+
+        test('uses the archive version only when build metadata is unavailable', () => {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgate-build-info-'));
+            try {
+                runHelperWithArgs('_cgateweb_record_installed_version', [dir, '3.3.2_1855']);
+                expect(fs.readFileSync(path.join(dir, '.version'), 'utf8')).toBe('3.3.2_1855\n');
+            } finally {
+                fs.rmSync(dir, { recursive: true, force: true });
+            }
+        });
+    });
+
     describe('_cgateweb_force_reinstall_requested', () => {
         test('returns 0 when cgate_force_reinstall is unset (default off)', () => {
             const out = callHelper('_cgateweb_force_reinstall_requested', {});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #66 by reading the installed C-Gate version and build from BuildInfo.txt instead of relying on the archive filename. Existing managed installations with an unknown marker are repaired on their next start.

Releases the accumulated changes as v1.27.0.

## Changes

- Read C-Gate's authoritative version and build metadata
- Refresh stale or unknown diagnostic version markers without reinstalling C-Gate
- Preserve archive-name fallback for older packages without build metadata
- Add installer helper coverage for metadata parsing and marker repair
- Bump package and add-on versions to 1.27.0 with release notes

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification
- [x] `npm run lint` passes locally
- [x] `npm run typecheck` passes locally

## Checklist

- [x] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [x] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-22c63784-7c17-4ebd-b531-53551af0ee47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-22c63784-7c17-4ebd-b531-53551af0ee47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

