### PR TITLE
Maintainability leftovers: settings, keys, discovery, import caps (no release)

### DIFF
--- a/src/cbusProjectParser.js
+++ b/src/cbusProjectParser.js
@@ -10,6 +10,13 @@ const { createLogger } = require('./logger');
 // otherwise exhaust process memory before xml2js parsing fails.
 const MAX_DECOMPRESSED_BYTES = 100 * 1024 * 1024; // 100MB
 
+// Bound xml2js work independently of byte size: a tiny document can still
+// contain millions of empty elements. Count of '<' tokens is a cheap proxy
+// for element count. Toolkit's DLT-tagged Group shape is ~18 tokens per
+// group; 2e6 leaves ~10x headroom over an 11k-group site while still
+// rejecting a small `<i/>` bomb (~8MB at 4 bytes/token).
+const MAX_XML_ELEMENT_TOKENS = 2000000;
+
 // Defence-in-depth: reject ZIP entry names containing path-traversal or
 // absolute paths. The parser does not write extracted files to disk, but
 // guarding here means a future change can't accidentally introduce one.
@@ -38,6 +45,9 @@ class CbusProjectParser {
     constructor(options = {}) {
         this.logger = createLogger({ component: 'CbusProjectParser' });
         this.maxDecompressedBytes = options.maxDecompressedBytes || MAX_DECOMPRESSED_BYTES;
+        this.maxXmlElementTokens = Number.isFinite(options.maxXmlElementTokens) && options.maxXmlElementTokens > 0
+            ? options.maxXmlElementTokens
+            : MAX_XML_ELEMENT_TOKENS;
     }
 
     /**
@@ -159,9 +169,14 @@ class CbusProjectParser {
         if (!xmlEntry) {
             xmlEntry = fileEntries.find(e => {
                 try {
-                    const head = e.getData().slice(0, 512).toString('utf8').replace(/^\uFEFF/, '').trimStart();
+                    // adm-zip fully inflates on getData(); check actual length
+                    // immediately, then sniff only the first 512 bytes of that
+                    // same buffer (no second inflate / second copy for the cap).
+                    const data = this._getEntryDataWithinCap(e);
+                    const head = data.slice(0, 512).toString('utf8').replace(/^\uFEFF/, '').trimStart();
                     return head.startsWith('<?xml') || /<(Installation|Network|Project)\b/i.test(head);
-                } catch {
+                } catch (err) {
+                    if (this._isZipBombError(err)) throw err;
                     return false;
                 }
             });
@@ -171,15 +186,17 @@ class CbusProjectParser {
                 throw new Error(`CBZ archive entry name rejected: ${xmlEntry.entryName}`);
             }
             this.logger.info(`Extracting ${xmlEntry.entryName} from CBZ`);
-            return { kind: 'xml', data: xmlEntry.getData().toString('utf8') };
+            return { kind: 'xml', data: this._getEntryDataWithinCap(xmlEntry).toString('utf8') };
         }
 
         // No XML — newer Toolkit (1.17.x) packs a SQLite project database.
         const dbEntry = fileEntries.find(e => {
             if (e.entryName.toLowerCase().endsWith('.db')) return true;
             try {
-                return this._isSqlite(e.getData().slice(0, 16));
-            } catch {
+                const data = this._getEntryDataWithinCap(e);
+                return this._isSqlite(data.slice(0, 16));
+            } catch (err) {
+                if (this._isZipBombError(err)) throw err;
                 return false;
             }
         });
@@ -188,10 +205,31 @@ class CbusProjectParser {
                 throw new Error(`CBZ archive entry name rejected: ${dbEntry.entryName}`);
             }
             this.logger.info(`Extracting SQLite project database ${dbEntry.entryName} from CBZ`);
-            return { kind: 'sqlite', data: dbEntry.getData() };
+            return { kind: 'sqlite', data: this._getEntryDataWithinCap(dbEntry) };
         }
 
         throw new Error('CBZ archive contains neither an XML export nor a SQLite project database (.db)');
+    }
+
+    /**
+     * Inflate a ZIP entry and reject if the actual buffer exceeds the cap.
+     * Declared header.size is attacker-controlled (and can under-report for
+     * STORED entries); never trust it alone after getData().
+     * @param {{ getData: () => Buffer, entryName?: string }} entry
+     * @returns {Buffer}
+     */
+    _getEntryDataWithinCap(entry) {
+        const data = entry.getData();
+        if (data.length > this.maxDecompressedBytes) {
+            throw new Error(
+                `CBZ archive decompressed size exceeds ${this.maxDecompressedBytes} bytes; rejecting (zip-bomb protection)`
+            );
+        }
+        return data;
+    }
+
+    _isZipBombError(err) {
+        return Boolean(err && typeof err.message === 'string' && /zip-bomb protection/i.test(err.message));
     }
 
     _isSqlite(buffer) {
@@ -270,11 +308,33 @@ class CbusProjectParser {
     }
 
     _parseXML(xmlString) {
+        // Bound size before regex/token work: a huge document must not pay
+        // for DTD scans or a full '<' walk only to be rejected on length.
+        if (typeof xmlString === 'string' && xmlString.length > this.maxDecompressedBytes) {
+            return Promise.reject(new Error(
+                `XML document exceeds ${this.maxDecompressedBytes} bytes; rejecting (zip-bomb protection)`
+            ));
+        }
         // Reject DTDs / entity declarations before handing to the XML parser —
         // xml2js (and libxml-backed parsers) can expand external entities or
         // blow up on billion-laughs style entity expansion.
         if (/<!DOCTYPE/i.test(xmlString) || /<!ENTITY/i.test(xmlString)) {
             return Promise.reject(new Error('XML with DTD or entity declarations is not supported'));
+        }
+        // Cap element-ish tokens ('<') so a small but densely nested / empty-tag
+        // document cannot exhaust CPU/memory inside xml2js.
+        if (typeof xmlString === 'string') {
+            let tokenCount = 0;
+            for (let i = 0; i < xmlString.length; i++) {
+                if (xmlString.charCodeAt(i) === 60) { // '<'
+                    tokenCount++;
+                    if (tokenCount > this.maxXmlElementTokens) {
+                        return Promise.reject(new Error(
+                            `XML document has too many elements; rejecting (max ${this.maxXmlElementTokens})`
+                        ));
+                    }
+                }
+            }
         }
         return new Promise((resolve, reject) => {
             parseString(xmlString, { explicitArray: false, ignoreAttrs: false, mergeAttrs: true }, (err, result) => {

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -1470,10 +1470,12 @@ function resolveSetting(settings, key) {
 }
 
 /**
- * resolveSetting, then optionally clamp with Math.max(min, value).
+ * resolveSetting, then Number() with a schema-default fallback for non-finite
+ * values, then optionally Math.max(min, n).
  *
- * Used for connection-pool and socket floors that already applied Math.max
- * after reading a setting.
+ * A typo like "sixty" becomes NaN; Math.max(min, NaN) is NaN, which would
+ * disable setInterval floors and unbounded caches. Fall back to the schema
+ * default so those call sites stay bounded.
  *
  * @param {Object|null|undefined} settings
  * @param {string} key
@@ -1481,11 +1483,12 @@ function resolveSetting(settings, key) {
  * @returns {number}
  */
 function resolveClampedSetting(settings, key, options = {}) {
-    const value = /** @type {number} */ (resolveSetting(settings, key));
+    const n = Number(resolveSetting(settings, key));
+    const resolved = Number.isFinite(n) ? n : Number(resolveSetting({}, key));
     if (options.min !== undefined) {
-        return Math.max(options.min, value);
+        return Math.max(options.min, resolved);
     }
-    return value;
+    return resolved;
 }
 
 /**

--- a/src/eventPublisher.js
+++ b/src/eventPublisher.js
@@ -364,6 +364,91 @@ const READING_KIND_HANDLERS = {
     }
 };
 
+/**
+ * Dispatch table for publishEvent after shared classification/setup:
+ * kind → handler(ep, ctx). Handlers keep the historical publish semantics;
+ * the table only removes the if/else chain among trigger / hvac / tilt / status.
+ */
+const EVENT_KIND_HANDLERS = {
+    trigger(ep, ctx) {
+        const eventPayload = ctx.rawLevel !== null
+            ? JSON.stringify({ event_type: 'trigger', level: ctx.rawLevel })
+            : JSON.stringify({ event_type: 'trigger' });
+
+        if (ep.logger.isLevelEnabled && ep.logger.isLevelEnabled('debug')) {
+            ep.logger.debug(
+                `C-Bus Trigger ${ctx.source}: ${ctx.network}/${ctx.application}/${ctx.group}`
+                + (ctx.rawLevel !== null ? ` level=${ctx.rawLevel}` : '')
+            );
+        }
+
+        ep._publishIfNeeded(
+            ctx.topics.event,
+            eventPayload,
+            ep._triggerMqttOptions
+        );
+    },
+
+    hvac(ep, ctx) {
+        ep._publishHvacEvent(
+            ctx.network,
+            ctx.application,
+            ctx.group,
+            ctx.rawLevel,
+            ctx.action,
+            ctx.source
+        );
+    },
+
+    tilt(ep, ctx) {
+        // Same 0-100 rounding as levelPercent (HA integer percent).
+        if (ep.logger.isLevelEnabled && ep.logger.isLevelEnabled('debug')) {
+            ep.logger.debug(
+                `C-Bus Tilt ${ctx.source}: ${ctx.network}/${ctx.application}/${ctx.group} ${ctx.levelPercent}%`
+            );
+        }
+
+        ep._publishIfNeeded(
+            `${MQTT_TOPIC_PREFIX_READ}/${ctx.network}/${ctx.application}/${ctx.group}/${MQTT_TOPIC_SUFFIX_TILT}`,
+            ctx.levelPercent.toString(),
+            ep.mqttOptions
+        );
+    },
+
+    // Lighting, cover, and PIR: state always; level/position unless PIR.
+    status(ep, ctx) {
+        if (ep.logger.isLevelEnabled && ep.logger.isLevelEnabled('debug')) {
+            ep.logger.debug(
+                `C-Bus Status ${ctx.source}: ${ctx.network}/${ctx.application}/${ctx.group} ${ctx.state}`
+                + (ctx.isPirSensor ? '' : ` (${ctx.levelPercent}%)`)
+            );
+        }
+
+        ep._publishIfNeeded(
+            ctx.topics.state,
+            ctx.state,
+            ep.mqttOptions
+        );
+
+        if (!ctx.isPirSensor) {
+            ep._publishIfNeeded(
+                ctx.topics.level,
+                ctx.levelPercent.toString(),
+                ep.mqttOptions
+            );
+
+            // Position mirrors level on a separate topic for the HA cover entity.
+            if (ctx.isCover) {
+                ep._publishIfNeeded(
+                    ctx.topics.position,
+                    ctx.levelPercent.toString(),
+                    ep.mqttOptions
+                );
+            }
+        }
+    }
+};
+
 class EventPublisher {
     /**
      * Creates a new EventPublisher instance.
@@ -483,11 +568,11 @@ class EventPublisher {
 
         let state;
         if (isPirSensor) {
-            // PIR sensors: state based on action (motion detected/cleared)
+            // PIR: ON/OFF from action (motion detected/cleared), not level.
             state = actionIsOn ? MQTT_STATE_ON : MQTT_STATE_OFF;
         } else {
-            // Covers and lighting: state based on raw level, not quantized
-            // percent — rawLevel 1-2 rounds to 0% but the device IS on/open.
+            // Covers and lighting: state from raw level, not quantized percent —
+            // rawLevel 1-2 rounds to 0% but the device IS on/open.
             state = rawLevel !== null
                 ? ((rawLevel > 0) ? MQTT_STATE_ON : MQTT_STATE_OFF)
                 : (actionIsOn ? MQTT_STATE_ON : MQTT_STATE_OFF);
@@ -495,11 +580,11 @@ class EventPublisher {
        
         // Emit event log entry for live event stream (before any early returns)
         if (this.onEventLog) {
-            const action = event.getAction();
+            const logAction = event.getAction();
             let eventType = 'update';
-            if (action === 'ramp') eventType = 'ramp';
-            else if (action === 'on') eventType = 'on';
-            else if (action === 'off') eventType = 'off';
+            if (logAction === 'ramp') eventType = 'ramp';
+            else if (logAction === 'on') eventType = 'on';
+            else if (logAction === 'off') eventType = 'off';
             this.onEventLog({
                 ts: Date.now(),
                 network: network,
@@ -510,77 +595,24 @@ class EventPublisher {
             });
         }
 
-        // Trigger groups publish as HA event entities - never retain
-        if (isTrigger) {
-            const eventPayload = rawLevel !== null
-                ? JSON.stringify({ event_type: 'trigger', level: rawLevel })
-                : JSON.stringify({ event_type: 'trigger' });
-
-            if (this.logger.isLevelEnabled && this.logger.isLevelEnabled('debug')) {
-                this.logger.debug(`C-Bus Trigger ${source}: ${network}/${application}/${group}` + (rawLevel !== null ? ` level=${rawLevel}` : ''));
-            }
-
-            // Trigger events must not be retained - always publish with retain: false
-            this._publishIfNeeded(
-                topics.event,
-                eventPayload,
-                this._triggerMqttOptions
-            );
-            return;
-        }
-
-        // HVAC groups publish temperature/mode to dedicated climate topics
-        if (isHvac) {
-            this._publishHvacEvent(network, application, group, rawLevel, action, source);
-            return;
-        }
-
-        // Tilt app groups publish tilt angle to the tilt topic only (0-100%)
-        if (isTiltApp) {
-            const tiltPercent = rawLevel !== null
-                ? Math.round(rawLevel / CGATE_LEVEL_MAX * 100)
-                : (actionIsOn ? 100 : 0);
-
-            if (this.logger.isLevelEnabled && this.logger.isLevelEnabled('debug')) {
-                this.logger.debug(`C-Bus Tilt ${source}: ${network}/${application}/${group} ${tiltPercent}%`);
-            }
-
-            this._publishIfNeeded(
-                `${MQTT_TOPIC_PREFIX_READ}/${network}/${application}/${group}/${MQTT_TOPIC_SUFFIX_TILT}`,
-                tiltPercent.toString(),
-                this.mqttOptions
-            );
-            return;
-        }
-
-        if (this.logger.isLevelEnabled && this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(`C-Bus Status ${source}: ${network}/${application}/${group} ${state}` + (isPirSensor ? '' : ` (${levelPercent}%)`));
-        }
-
-        // Publish state message directly (no throttle)
-        this._publishIfNeeded(
-            topics.state,
+        const kind = isTrigger ? 'trigger'
+            : isHvac ? 'hvac'
+                : isTiltApp ? 'tilt'
+                    : 'status';
+        EVENT_KIND_HANDLERS[kind](this, {
+            network,
+            application,
+            group,
+            action,
+            rawLevel,
+            actionIsOn,
+            source,
+            topics,
+            isPirSensor,
+            isCover,
             state,
-            this.mqttOptions
-        );
-
-        // Publish level/position message for non-PIR sensors
-        if (!isPirSensor) {
-            this._publishIfNeeded(
-                topics.level,
-                levelPercent.toString(),
-                this.mqttOptions
-            );
-
-            // Also publish position for covers (same value, different topic for HA cover entity)
-            if (isCover) {
-                this._publishIfNeeded(
-                    topics.position,
-                    levelPercent.toString(),
-                    this.mqttOptions
-                );
-            }
-        }
+            levelPercent
+        });
     }
 
     /**

--- a/src/eventPublisher.js
+++ b/src/eventPublisher.js
@@ -1,6 +1,7 @@
 // @ts-check
 const { createLogger, resolveLogLevelFromSettings } = require('./logger');
-const { clampSetting, evictOldestFifo, cbusLevelToTemperature } = require('./utils');
+const { evictOldestFifo, cbusLevelToTemperature } = require('./utils');
+const { resolveClampedSetting } = require('./config/schema');
 const {
     MQTT_TOPIC_PREFIX_READ,
     MQTT_TOPIC_SUFFIX_STATE,
@@ -386,9 +387,9 @@ class EventPublisher {
         this.labelLoader = options.labelLoader || null;
         this.coverRampTracker = options.coverRampTracker || null;
         this.onEventLog = options.onEventLog || null;
-        this.eventPublishDedupWindowMs = clampSetting(this.settings.eventPublishDedupWindowMs, 0, 0);
-        this.eventPublishDedupMaxEntries = clampSetting(this.settings.eventPublishDedupMaxEntries, 100, 5000);
-        this.topicCacheMaxEntries = clampSetting(this.settings.topicCacheMaxEntries, 100, 5000);
+        this.eventPublishDedupWindowMs = resolveClampedSetting(this.settings, 'eventPublishDedupWindowMs', { min: 0 });
+        this.eventPublishDedupMaxEntries = resolveClampedSetting(this.settings, 'eventPublishDedupMaxEntries', { min: 100 });
+        this.topicCacheMaxEntries = resolveClampedSetting(this.settings, 'topicCacheMaxEntries', { min: 100 });
         this.eventPublishCoalesce = this.settings.eventPublishCoalesce === true;
         this._recentPublishes = new Map();
         this._topicCache = new Map();

--- a/src/haBridgeDiagnostics.js
+++ b/src/haBridgeDiagnostics.js
@@ -2,7 +2,7 @@
 const fs = require('fs');
 const { createLogger } = require('./logger');
 const { MQTT_TOPIC_STATUS, MQTT_RETAINED_STATE_OPTIONS, entityIdFields, HA_COMPONENT_SENSOR, HA_COMPONENT_BINARY_SENSOR, HA_DEVICE_VIA } = require('./constants');
-const { clampSetting } = require('./utils');
+const { resolveClampedSetting } = require('./config/schema');
 
 const CGATE_VERSION_FILE = '/data/cgate/.version';
 
@@ -21,7 +21,7 @@ class HaBridgeDiagnostics {
             return;
         }
 
-        const intervalSeconds = clampSetting(this.settings.ha_bridge_diagnostics_interval_sec, 10, 60);
+        const intervalSeconds = resolveClampedSetting(this.settings, 'ha_bridge_diagnostics_interval_sec', { min: 10 });
         if (this._intervalId) {
             clearInterval(this._intervalId);
         }

--- a/src/haDiscoveryPublishers.js
+++ b/src/haDiscoveryPublishers.js
@@ -417,43 +417,28 @@ class _HaDiscoveryPublishers {
      * @private
      */
     _publishLightingGroupEntity(networkId, appId, groupId, group, labelKey, spec) {
-        const { labelMap, entityIds, areas } = this._labelSnapshot;
+        const { finalLabel, uniqueId, entityId, area, discoveryTopic } = this._resolveEntityIdentity({
+            networkId, appId, groupId, labelKey,
+            component: spec.component,
+            fallbackLabel: spec.fallbackLabel,
+            groupLabel: group.Label,
+            labels: this._labelSnapshot
+        });
 
-        const customLabel = labelMap.get(labelKey);
-        const groupLabel = group.Label;
-        const finalLabel = customLabel || groupLabel || spec.fallbackLabel;
-        if (customLabel) this.labelStats.custom++;
-        else if (groupLabel) this.labelStats.treexml++;
-        else this.labelStats.fallback++;
-
-        const uniqueId = `cgateweb_${networkId}_${appId}_${groupId}`;
-        const entityId = entityIds.get(labelKey);
-        const area = areas && areas.get(labelKey);
-        const discoveryTopic = `${this.settings.ha_discovery_prefix}/${spec.component}/${uniqueId}/${HA_DISCOVERY_SUFFIX}`;
-
-        const payload = {
-            name: null,
-            unique_id: uniqueId,
-            ...(entityId && entityIdFields(spec.component, entityId)),
-            ...spec.fields({
+        // command topics must NOT be retained: a retained command replays to
+        // cgateweb on every reconnect and re-toggles the light (see _createDiscovery).
+        this._finishTreeEntity({
+            discoveryTopic, uniqueId, entityId,
+            component: spec.component,
+            fields: spec.fields({
                 read: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/${groupId}`,
                 write: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}`
             }),
-            qos: 0,
-            // command topics must NOT be retained: a retained command replays to
-            // cgateweb on every reconnect and re-toggles the light (see _createDiscovery).
-            device: buildDeviceBlock({
-                identifiers: [uniqueId],
-                name: finalLabel,
-                model: HA_MODEL_LIGHTING,
-                area
-            }),
-            origin: buildOriginBlock()
-        };
-
-        this._publish(discoveryTopic, JSON.stringify(payload), MQTT_RETAINED_STATE_OPTIONS);
-        if (this._currentRunTopics) this._currentRunTopics.add(discoveryTopic);
-        this.discoveryCount++;
+            deviceIdentifiers: [uniqueId],
+            deviceName: finalLabel,
+            model: HA_MODEL_LIGHTING,
+            area
+        });
     }
 
     /**
@@ -912,9 +897,62 @@ class _HaDiscoveryPublishers {
     }
 
     /**
-     * Finish an event-driven discovery entity: wrap component-specific fields
-     * with the shared name / unique_id / entity-id hint / qos / device / origin
-     * shell and publish via {@link _publishEventDrivenConfig}.
+     * Assemble the shared discovery shell (name / unique_id / entity-id hint /
+     * qos / device / origin) around component-specific fields and publish.
+     * Does not track topics — callers choose tree ({@link _finishTreeEntity})
+     * or event-driven ({@link _finishEventDrivenEntity}) registration.
+     *
+     * @param {Object} spec
+     * @param {string} spec.discoveryTopic
+     * @param {string} spec.uniqueId
+     * @param {string} [spec.entityId]
+     * @param {string} spec.component
+     * @param {string|null} [spec.name=null]
+     * @param {Object} spec.fields
+     * @param {string[]} spec.deviceIdentifiers
+     * @param {string} spec.deviceName
+     * @param {string} spec.model
+     * @param {string} [spec.area]
+     * @private
+     */
+    _publishDiscoveryPayload({
+        discoveryTopic, uniqueId, entityId, component, name = null, fields,
+        deviceIdentifiers, deviceName, model, area
+    }) {
+        this._publish(discoveryTopic, JSON.stringify({
+            name,
+            unique_id: uniqueId,
+            ...(entityId && entityIdFields(component, entityId)),
+            ...fields,
+            qos: 0,
+            device: buildDeviceBlock({
+                identifiers: deviceIdentifiers,
+                name: deviceName,
+                model,
+                area
+            }),
+            origin: buildOriginBlock()
+        }), MQTT_RETAINED_STATE_OPTIONS);
+    }
+
+    /**
+     * Finish a tree-run discovery entity: publish via
+     * {@link _publishDiscoveryPayload}, record the topic on the current run
+     * (stale cleanup), and bump the entity counter.
+     *
+     * @param {Object} spec - Same shape as {@link _publishDiscoveryPayload}.
+     * @private
+     */
+    _finishTreeEntity(spec) {
+        this._publishDiscoveryPayload(spec);
+        if (this._currentRunTopics) this._currentRunTopics.add(spec.discoveryTopic);
+        this.discoveryCount++;
+    }
+
+    /**
+     * Finish an event-driven discovery entity: publish via
+     * {@link _publishDiscoveryPayload}, then register on the session-wide and
+     * event-driven topic sets (so tree runs don't retract it).
      *
      * @param {Object} spec
      * @param {string} spec.discoveryTopic
@@ -934,20 +972,13 @@ class _HaDiscoveryPublishers {
         discoveryTopic, uniqueId, entityId, component, name = null, fields,
         deviceIdentifiers, deviceName, model, area, logInfo
     }) {
-        this._publishEventDrivenConfig(discoveryTopic, {
-            name,
-            unique_id: uniqueId,
-            ...(entityId && entityIdFields(component, entityId)),
-            ...fields,
-            qos: 0,
-            device: buildDeviceBlock({
-                identifiers: deviceIdentifiers,
-                name: deviceName,
-                model,
-                area
-            }),
-            origin: buildOriginBlock()
+        this._publishDiscoveryPayload({
+            discoveryTopic, uniqueId, entityId, component, name, fields,
+            deviceIdentifiers, deviceName, model, area
         });
+        this._publishedTopics.add(discoveryTopic);
+        this._eventDrivenDiscoveryTopics.add(discoveryTopic);
+        this.discoveryCount++;
         if (logInfo) this.logger.info(logInfo);
     }
 
@@ -1368,23 +1399,6 @@ class _HaDiscoveryPublishers {
     }
 
     /**
-     * Publish one event-driven discovery config and register it: session-wide
-     * published-topics set (stale cleanup), event-driven set (so tree runs
-     * don't retract it) and the entity counter. Inverse of
-     * {@link _retractEventDrivenConfig}.
-     *
-     * @param {string} topic
-     * @param {Object} payload - Discovery config payload (JSON-stringified here).
-     * @private
-     */
-    _publishEventDrivenConfig(topic, payload) {
-        this._publish(topic, JSON.stringify(payload), MQTT_RETAINED_STATE_OPTIONS);
-        this._publishedTopics.add(topic);
-        this._eventDrivenDiscoveryTopics.add(topic);
-        this.discoveryCount++;
-    }
-
-    /**
      * Retract one event-driven discovery config: clear the retained message and
      * forget it, so a later tree run's stale cleanup doesn't try to clear it
      * again and the replay cache doesn't resurrect it on a broker reconnect.
@@ -1629,48 +1643,39 @@ class _HaDiscoveryPublishers {
 
         const { readBase, writeBase } = this._topicBases(networkId, appId, groupId);
 
-        const payload = {
-            name: null,
-            unique_id: uniqueId,
-            ...(entityId && entityIdFields(HA_COMPONENT_CLIMATE, entityId)),
+        // command topics must NOT be retained (see _createDiscovery note)
+        this._finishTreeEntity({
+            discoveryTopic, uniqueId, entityId,
+            component: HA_COMPONENT_CLIMATE,
+            fields: {
+                // Current temperature: reported by C-Gate as a status level on this group.
+                // EventPublisher decodes the level to °C before it reaches this topic, using the
+                // inverse of the setpoint encoding above:
+                //   temperature = level / 2   (0.5°C resolution; see TODO above)
+                current_temperature_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_HVAC_CURRENT_TEMP}`,
 
-            // Current temperature: reported by C-Gate as a status level on this group.
-            // EventPublisher decodes the level to °C before it reaches this topic, using the
-            // inverse of the setpoint encoding above:
-            //   temperature = level / 2   (0.5°C resolution; see TODO above)
-            current_temperature_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_HVAC_CURRENT_TEMP}`,
+                // Target temperature setpoint — command and state topics
+                temperature_command_topic: `${writeBase}/${MQTT_CMD_TYPE_HVAC_SETPOINT}`,
+                temperature_state_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_HVAC_SETPOINT}`,
 
-            // Target temperature setpoint — command and state topics
-            temperature_command_topic: `${writeBase}/${MQTT_CMD_TYPE_HVAC_SETPOINT}`,
-            temperature_state_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_HVAC_SETPOINT}`,
+                // Mode control topics
+                mode_command_topic: `${writeBase}/${MQTT_CMD_TYPE_HVAC_MODE}`,
+                mode_state_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_HVAC_MODE}`,
 
-            // Mode control topics
-            mode_command_topic: `${writeBase}/${MQTT_CMD_TYPE_HVAC_MODE}`,
-            mode_state_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_HVAC_MODE}`,
+                // Deliberately off/auto only — do not add heat/cool/fan_only back here.
+                // This path has exactly one group level to work with: the router can only
+                // translate a mode into C-Gate ON or OFF, and the event side can only infer
+                // the same two states from what C-Bus reports. Advertising more modes gives
+                // Home Assistant buttons that send a bare ON and then snap back to auto.
+                modes: ['off', 'auto'],
 
-            // Deliberately off/auto only — do not add heat/cool/fan_only back here.
-            // This path has exactly one group level to work with: the router can only
-            // translate a mode into C-Gate ON or OFF, and the event side can only infer
-            // the same two states from what C-Bus reports. Advertising more modes gives
-            // Home Assistant buttons that send a bare ON and then snap back to auto.
-            modes: ['off', 'auto'],
-
-            ...this._climateRangeFields(),
-
-            qos: 0,
-            // command topics must NOT be retained (see _createDiscovery note)
-            device: buildDeviceBlock({
-                identifiers: [uniqueId],
-                name: finalLabel,
-                model: 'HVAC Zone (Air Conditioning)',
-                area
-            }),
-            origin: buildOriginBlock()
-        };
-
-        this._publish(discoveryTopic, JSON.stringify(payload), MQTT_RETAINED_STATE_OPTIONS);
-        if (this._currentRunTopics) this._currentRunTopics.add(discoveryTopic);
-        this.discoveryCount++;
+                ...this._climateRangeFields()
+            },
+            deviceIdentifiers: [uniqueId],
+            deviceName: finalLabel,
+            model: 'HVAC Zone (Air Conditioning)',
+            area
+        });
     }
 
     _createDiscovery(networkId, appId, groupId, groupLabel, config) {
@@ -1697,47 +1702,40 @@ class _HaDiscoveryPublishers {
             ? `${readBase}/${MQTT_TOPIC_SUFFIX_EVENT}`
             : `${readBase}/${MQTT_TOPIC_SUFFIX_STATE}`;
 
-        const payload = {
-            name: null,
-            unique_id: uniqueId,
-            ...(entityId && entityIdFields(config.component, entityId)),
-            state_topic: stateTopic,
-            ...(!config.omitCommandTopic && { command_topic: `${writeBase}/${MQTT_CMD_TYPE_SWITCH}` }),
-            ...config.payloads,
-            ...(config.positionSupport && {
-                position_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_POSITION}`,
-                set_position_topic: `${writeBase}/${MQTT_CMD_TYPE_POSITION}`,
-                stop_topic: `${writeBase}/${MQTT_CMD_TYPE_STOP}`,
-                payload_stop: MQTT_COMMAND_STOP,
-                position_open: 100,
-                position_closed: 0,
-                optimistic: false
-            }),
-            ...(config.positionSupport && this.settings.ha_discovery_cover_tilt_app_id && {
-                tilt_status_topic: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${this.settings.ha_discovery_cover_tilt_app_id}/${groupId}/${MQTT_TOPIC_SUFFIX_TILT}`,
-                tilt_command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${this.settings.ha_discovery_cover_tilt_app_id}/${groupId}/${MQTT_CMD_TYPE_TILT}`,
-                tilt_min: 0,
-                tilt_max: 100,
-                tilt_optimistic: false
-            }),
-            qos: 0,
-            // NOTE: command topics must NOT be retained. A retained command sits on the
-            // broker and is redelivered to cgateweb on every (re)connect, replaying stale
-            // ON/OFF/RAMP commands that toggle devices unexpectedly. State retention is
-            // handled separately by the read/state publish options, not here.
-            ...(config.deviceClass && { device_class: config.deviceClass }),
-            device: buildDeviceBlock({
-                identifiers: [uniqueId],
-                name: finalLabel,
-                model: config.model,
-                area
-            }),
-            origin: buildOriginBlock()
-        };
-
-        this._publish(discoveryTopic, JSON.stringify(payload), MQTT_RETAINED_STATE_OPTIONS);
-        if (this._currentRunTopics) this._currentRunTopics.add(discoveryTopic);
-        this.discoveryCount++;
+        // NOTE: command topics must NOT be retained. A retained command sits on the
+        // broker and is redelivered to cgateweb on every (re)connect, replaying stale
+        // ON/OFF/RAMP commands that toggle devices unexpectedly. State retention is
+        // handled separately by the read/state publish options, not here.
+        this._finishTreeEntity({
+            discoveryTopic, uniqueId, entityId,
+            component: config.component,
+            fields: {
+                state_topic: stateTopic,
+                ...(!config.omitCommandTopic && { command_topic: `${writeBase}/${MQTT_CMD_TYPE_SWITCH}` }),
+                ...config.payloads,
+                ...(config.positionSupport && {
+                    position_topic: `${readBase}/${MQTT_TOPIC_SUFFIX_POSITION}`,
+                    set_position_topic: `${writeBase}/${MQTT_CMD_TYPE_POSITION}`,
+                    stop_topic: `${writeBase}/${MQTT_CMD_TYPE_STOP}`,
+                    payload_stop: MQTT_COMMAND_STOP,
+                    position_open: 100,
+                    position_closed: 0,
+                    optimistic: false
+                }),
+                ...(config.positionSupport && this.settings.ha_discovery_cover_tilt_app_id && {
+                    tilt_status_topic: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${this.settings.ha_discovery_cover_tilt_app_id}/${groupId}/${MQTT_TOPIC_SUFFIX_TILT}`,
+                    tilt_command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${this.settings.ha_discovery_cover_tilt_app_id}/${groupId}/${MQTT_CMD_TYPE_TILT}`,
+                    tilt_min: 0,
+                    tilt_max: 100,
+                    tilt_optimistic: false
+                }),
+                ...(config.deviceClass && { device_class: config.deviceClass })
+            },
+            deviceIdentifiers: [uniqueId],
+            deviceName: finalLabel,
+            model: config.model,
+            area
+        });
 
         // For trigger groups, also publish companion entities:
         // - a button entity so HA automations can fire the C-Bus trigger via the trigger topic

--- a/src/serialDeviceRecovery.js
+++ b/src/serialDeviceRecovery.js
@@ -5,8 +5,7 @@ const nodeFs = require('fs');
 const nodePath = require('path');
 const { execFileSync } = require('child_process');
 const { backoffDelay } = require('./backoff');
-const { clampSetting } = require('./utils');
-const { defaultSettings } = require('./defaultSettings');
+const { resolveSetting, resolveClampedSetting } = require('./config/schema');
 
 const DEFAULT_DEVICE_FILE = '/run/cgateweb/serial-device';
 const DEFAULT_RECOVER_SCRIPT = '/usr/bin/cgateweb-recover-serial';
@@ -68,32 +67,21 @@ class SerialDeviceRecovery {
 
     /**
      * @param {string} key
-     * @returns {any} The configured value, or the shipped default.
+     * @returns {any} The configured value, or the schema default.
      */
     _setting(key) {
-        const value = this.settings[key];
-        return value === undefined || value === null ? defaultSettings[key] : value;
+        return resolveSetting(this.settings, key);
     }
 
     /**
-     * A numeric setting, clamped the way the rest of src/ clamps them.
-     *
-     * Every number this class reads gates a C-Gate restart, and a bare Number()
-     * of a mistyped option yields NaN, which fails both guards *open*:
-     * `attempts >= NaN` is false, so the cap never trips, and
-     * `now < lastAttemptAt + NaN` is false, so the backoff never waits. A single
-     * typo in one option was therefore enough to reproduce a restart-every-poll
-     * loop. clampSetting falls back to the shipped default for NaN (and for 0,
-     * which is never a sensible value for any of these) and then applies a
-     * floor, so no configuration can produce a value that disables the bound it
-     * is meant to express.
+     * A numeric setting with a hard floor (schema default if the value is not finite).
      *
      * @param {string} key
      * @param {number} floor
      * @returns {number}
      */
     _clampedSetting(key, floor) {
-        return clampSetting(this.settings[key], floor, defaultSettings[key]);
+        return resolveClampedSetting(this.settings, key, { min: floor });
     }
 
     /** @returns {boolean} True only when a local serial PCI is in play at all. */

--- a/src/staleDeviceDetector.js
+++ b/src/staleDeviceDetector.js
@@ -1,8 +1,7 @@
 // @ts-check
 const { createLogger } = require('./logger');
 const { MQTT_TOPIC_STATUS, MQTT_RETAINED_STATE_OPTIONS, entityIdFields, HA_COMPONENT_SENSOR, HA_DEVICE_VIA } = require('./constants');
-const { clampSetting } = require('./utils');
-const { resolveSetting } = require('./config/schema');
+const { resolveClampedSetting, resolveSetting } = require('./config/schema');
 
 /**
  * Periodically checks for C-Bus devices that have not reported a state change
@@ -48,7 +47,7 @@ class StaleDeviceDetector {
             return;
         }
 
-        const intervalSec = clampSetting(this.settings.stale_device_check_interval_sec, 60, 3600);
+        const intervalSec = resolveClampedSetting(this.settings, 'stale_device_check_interval_sec', { min: 60 });
 
         this._publishDiscovery();
         this._discoveryPublished = true;
@@ -89,7 +88,7 @@ class StaleDeviceDetector {
      */
     _check() {
         try {
-            const thresholdMs = clampSetting(this.settings.stale_device_threshold_hours, 1, 24) * 60 * 60 * 1000;
+            const thresholdMs = resolveClampedSetting(this.settings, 'stale_device_threshold_hours', { min: 1 }) * 60 * 60 * 1000;
             const staleDevices = this._getStaleDevices(thresholdMs);
             this._publishStaleCount(staleDevices.length, staleDevices);
         } catch (error) {
@@ -136,7 +135,7 @@ class StaleDeviceDetector {
      * @private
      */
     _publishStaleCount(count, staleDevices) {
-        const thresholdHours = clampSetting(this.settings.stale_device_threshold_hours, 1, 24);
+        const thresholdHours = resolveClampedSetting(this.settings, 'stale_device_threshold_hours', { min: 1 });
 
         this.mqttClient.publish('cbus/bridge/stale_devices', String(count), MQTT_RETAINED_STATE_OPTIONS);
 

--- a/src/stateResyncCoordinator.js
+++ b/src/stateResyncCoordinator.js
@@ -1,6 +1,8 @@
 // @ts-check
 'use strict';
 
+const { resolveClampedSetting } = require('./config/schema');
+
 /**
  * Triggers that also need the retained HA Discovery configs replayed, not just
  * state. A broker restart without persistence drops the configs, so the entities
@@ -69,7 +71,7 @@ class StateResyncCoordinator {
         this._pendingTriggers.add(trigger);
 
         if (this._pending) clearTimeout(this._pending);
-        const debounceMs = Number(this.settings.stateResyncDebounceMs) || 5000;
+        const debounceMs = resolveClampedSetting(this.settings, 'stateResyncDebounceMs', { min: 0 });
         this._pending = setTimeout(() => this._runResync(), debounceMs);
         if (typeof this._pending.unref === 'function') this._pending.unref();
         return true;

--- a/src/web/apiAuth.js
+++ b/src/web/apiAuth.js
@@ -2,6 +2,25 @@
 const crypto = require('crypto');
 
 /**
+ * Normalize a configured web API key for auth checks.
+ *
+ * resolveSetting preserves empty strings (unlike `||`), and the HA add-on
+ * default for web_api_key is an empty field because Ingress authenticates.
+ * Trimming then treating blank as unset keeps that default from becoming a
+ * valid password (timingSafeEqual against an empty provided key) while still
+ * accepting keys the operator padded with whitespace.
+ *
+ * @param {unknown} raw
+ * @returns {string|null}
+ */
+function normalizeApiKey(raw) {
+    if (raw === null || raw === undefined) return null;
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim();
+    return trimmed === '' ? null : trimmed;
+}
+
+/**
  * API route classification and authorization: API key / bearer checks and
  * Home Assistant ingress request detection.
  */
@@ -13,7 +32,7 @@ class ApiAuth {
      * @param {Function} options.getBasePath - Returns the current ingress base path (may change after startup)
      */
     constructor({ apiKey, allowUnauthenticatedMutations = false, getBasePath }) {
-        this.apiKey = apiKey || null;
+        this.apiKey = normalizeApiKey(apiKey);
         this.allowUnauthenticatedMutations = allowUnauthenticatedMutations === true;
         this.getBasePath = getBasePath;
     }

--- a/src/webServer.js
+++ b/src/webServer.js
@@ -136,7 +136,6 @@ class WebServer {
         this.eventStream = options.eventStream || null;
         this.getStatus = options.getStatus || (() => ({}));
         this.deviceStateManager = options.deviceStateManager || null;
-        this.apiKey = options.apiKey || null;
         this.allowUnauthenticatedMutations = options.allowUnauthenticatedMutations === true;
         this.allowedOrigins = Array.isArray(options.allowedOrigins)
             ? options.allowedOrigins
@@ -172,10 +171,11 @@ class WebServer {
         }
 
         this._apiAuth = new ApiAuth({
-            apiKey: this.apiKey,
+            apiKey: options.apiKey,
             allowUnauthenticatedMutations: this.allowUnauthenticatedMutations,
             getBasePath: () => this.basePath
         });
+        this.apiKey = this._apiAuth.apiKey;
         this._rateLimiter = new RateLimiter({
             windowMs: this.rateLimitWindowMs,
             maxRequests: this.maxMutationRequestsPerWindow
@@ -213,7 +213,14 @@ class WebServer {
         });
         this._staticFiles = new StaticFileServer({ logger: this.logger });
 
-        if (!this.apiKey && this.allowUnauthenticatedMutations) {
+        if (typeof options.apiKey === 'string' && this.apiKey === null) {
+            // Constructor-once: add-on password fields often submit "" or spaces.
+            this.logger.warn(
+                'Web API key is empty after trimming; treating as unset. '
+                + 'Mutating routes require Home Assistant Ingress or loopback '
+                + '(with web_allow_unauthenticated_mutations).'
+            );
+        } else if (!this.apiKey && this.allowUnauthenticatedMutations) {
             this.logger.warn('Web API key not configured; mutating endpoints are unauthenticated due to explicit override.');
         } else if (!this.apiKey) {
             this.logger.info('Web API key not configured; mutating endpoints require explicit unsafe override.');

--- a/tests/cbusProjectParser.test.js
+++ b/tests/cbusProjectParser.test.js
@@ -210,6 +210,20 @@ describe('CbusProjectParser', () => {
                 .rejects.toThrow('XML with DTD or entity declarations is not supported');
         });
 
+        it('rejects XML longer than maxDecompressedBytes before scanning DTDs', async () => {
+            const tiny = new CbusProjectParser({ maxDecompressedBytes: 50 });
+            const xml = '<?xml version="1.0"?><!DOCTYPE foo [<!ENTITY x "y">]>' + 'x'.repeat(100);
+            await expect(tiny.parseXML(xml))
+                .rejects.toThrow(/zip-bomb protection|exceeds .* bytes/i);
+        });
+
+        it('rejects XML with an excessive element-token count', async () => {
+            const tiny = new CbusProjectParser({ maxXmlElementTokens: 8 });
+            const xml = '<?xml version="1.0"?><r>' + '<i/>'.repeat(10) + '</r>';
+            await expect(tiny.parseXML(xml))
+                .rejects.toThrow(/too many elements/i);
+        });
+
         it('should handle Label attribute as alternative to TagName', async () => {
             const xml = `<?xml version="1.0"?>
                 <Network Address="254">
@@ -340,6 +354,27 @@ describe('CbusProjectParser', () => {
 
             await expect(tinyCapParser.parse(zipBuffer, 'bomb.cbz'))
                 .rejects.toThrow(/zip-bomb protection|decompressed size exceeds/i);
+        });
+
+        // Declared header.size is attacker-controlled. For STORED entries
+        // adm-zip returns the real payload length regardless of the lie, so a
+        // small declared size must not bypass the post-inflate cap.
+        it('rejects a CBZ whose actual inflated size exceeds the cap despite a small declared size', () => {
+            const tinyCapParser = new CbusProjectParser({ maxDecompressedBytes: 1000 });
+            const zip = new AdmZip();
+            const content = Buffer.concat([
+                Buffer.from('<?xml version="1.0"?><Network Address="254"/>'),
+                Buffer.alloc(5000, 0x41)
+            ]);
+            const entry = zip.addFile('project.xml', content);
+            // Force STORED so getData returns the full payload even when size is lied about.
+            entry.header.method = 0;
+            const rebuilt = new AdmZip(zip.toBuffer());
+            for (const e of rebuilt.getEntries()) {
+                if (!e.isDirectory) e.header.size = 100; // under the cap, but actual is ~5KB
+            }
+            expect(() => tinyCapParser._extractCBZ(rebuilt.toBuffer()))
+                .toThrow(/zip-bomb protection|decompressed size exceeds/i);
         });
 
         // AdmZip's addFile sanitises path-traversal on write, so we cannot

--- a/tests/cgateConnectionPool.test.js
+++ b/tests/cgateConnectionPool.test.js
@@ -648,6 +648,63 @@ describe('CgateConnectionPool', () => {
 
             await expect(pool.execute('cmd\n')).rejects.toThrow('No healthy connections available in pool');
         });
+
+        it('spreads concurrent execute() calls across least-loaded connections', async () => {
+            // Hold each sendWithBackpressure pending so in-flight counts stay
+            // elevated while the next execute() picks the next least-loaded
+            // connection. Proves load spreads rather than pinning one socket.
+            const connections = await startWithConnections();
+            const resolvers = [];
+            for (const c of connections) {
+                c.sendWithBackpressure = jest.fn().mockImplementation(() => new Promise((resolve) => {
+                    resolvers.push(resolve);
+                }));
+            }
+
+            const p0 = pool.execute('cmd-0\n');
+            await Promise.resolve();
+            expect(pool.connectionInFlight.get(connections[0])).toBe(1);
+            expect(connections[0].sendWithBackpressure).toHaveBeenCalledWith('cmd-0\n');
+
+            const p1 = pool.execute('cmd-1\n');
+            await Promise.resolve();
+            expect(pool.connectionInFlight.get(connections[1])).toBe(1);
+            expect(connections[1].sendWithBackpressure).toHaveBeenCalledWith('cmd-1\n');
+
+            const p2 = pool.execute('cmd-2\n');
+            await Promise.resolve();
+            expect(pool.connectionInFlight.get(connections[2])).toBe(1);
+            expect(connections[2].sendWithBackpressure).toHaveBeenCalledWith('cmd-2\n');
+
+            // Three distinct connections each hold one in-flight command
+            expect(resolvers).toHaveLength(3);
+            for (const c of connections) {
+                expect(pool.connectionInFlight.get(c)).toBe(1);
+                expect(c.sendWithBackpressure).toHaveBeenCalledTimes(1);
+            }
+
+            for (const resolve of resolvers) resolve(true);
+            await expect(Promise.all([p0, p1, p2])).resolves.toEqual([true, true, true]);
+            for (const c of connections) {
+                expect(pool.connectionInFlight.get(c) || 0).toBe(0);
+            }
+        });
+
+        it('marks connection unhealthy and tries next when sendWithBackpressure throws', async () => {
+            const connections = await startWithConnections();
+            connections[0].sendWithBackpressure = jest.fn().mockRejectedValue(new Error('socket write failed'));
+            connections[1].sendWithBackpressure = jest.fn().mockResolvedValue(true);
+            connections[2].sendWithBackpressure = jest.fn().mockResolvedValue(true);
+
+            const markSpy = jest.spyOn(pool, '_markConnectionUnhealthy');
+            const result = await pool.execute('cmd\n');
+
+            expect(result).toBe(true);
+            expect(markSpy).toHaveBeenCalledWith(connections[0]);
+            expect(connections[0].sendWithBackpressure).toHaveBeenCalled();
+            expect(connections[1].sendWithBackpressure).toHaveBeenCalled();
+            expect(pool.connectionInFlight.get(connections[0]) || 0).toBe(0);
+        });
     });
 
     describe('Health monitoring', () => {

--- a/tests/config/resolveSetting.test.js
+++ b/tests/config/resolveSetting.test.js
@@ -58,9 +58,22 @@ describe('resolveClampedSetting', () => {
         expect(resolveClampedSetting({ connectionTimeout: 500 }, 'connectionTimeout', { min: 1000 })).toBe(1000);
         expect(resolveClampedSetting({ connectionTimeout: 0 }, 'connectionTimeout', { min: 1000 })).toBe(1000);
         expect(resolveClampedSetting({ connectionPoolSize: 0 }, 'connectionPoolSize', { min: 1 })).toBe(1);
+        // Interval floors used by stale-device / diagnostics: 0 clamps to min, not the schema default
+        expect(resolveClampedSetting({ stale_device_check_interval_sec: 0 }, 'stale_device_check_interval_sec', { min: 60 })).toBe(60);
+        expect(resolveClampedSetting({ ha_bridge_diagnostics_interval_sec: 0 }, 'ha_bridge_diagnostics_interval_sec', { min: 10 })).toBe(10);
     });
 
     it('returns the resolved value when no min is given', () => {
         expect(resolveClampedSetting({ connectionTimeout: 0 }, 'connectionTimeout')).toBe(0);
+    });
+
+    it('falls back to the schema default when the configured value is not finite', () => {
+        expect(resolveClampedSetting(
+            { ha_bridge_diagnostics_interval_sec: 'sixty' },
+            'ha_bridge_diagnostics_interval_sec',
+            { min: 10 }
+        )).toBe(60);
+        expect(resolveClampedSetting({ connectionTimeout: Number.NaN }, 'connectionTimeout', { min: 1000 })).toBe(5000);
+        expect(resolveClampedSetting({ connectionTimeout: Infinity }, 'connectionTimeout', { min: 1000 })).toBe(5000);
     });
 });

--- a/tests/eventPublisher.test.js
+++ b/tests/eventPublisher.test.js
@@ -96,122 +96,48 @@ describe('EventPublisher', () => {
             );
         });
 
-        it('should publish lighting device ON event with state and level', () => {
-            const eventData = 'lighting on 254/56/16';
-            const event = new CBusEvent(eventData);
-            
+        it.each([
+            ['lighting on 254/56/16', 'ON', '100', 'ON (100%)'],
+            ['lighting off 254/56/16', 'OFF', '0', 'OFF (0%)'],
+            ['lighting ramp 254/56/16 128', 'ON', '50', null], // 128/255 → 50%
+        ])('should publish %s with state and level', (line, state, level, debugSuffix) => {
+            const event = new CBusEvent(line);
+
             eventPublisher.publishEvent(event, '(Test)');
 
             expect(mockPublishFn).toHaveBeenCalledTimes(2);
-            
-            // Check state message
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/16/state',
-                'ON',
-                mockMqttOptions
+                'cbus/read/254/56/16/state', state, mockMqttOptions
             );
-            
-            // Check level message (ON events assume 100%)
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/16/level',
-                '100',
-                mockMqttOptions
+                'cbus/read/254/56/16/level', level, mockMqttOptions
             );
-
-            expect(mockLogger.debug).toHaveBeenCalledWith(
-                expect.stringContaining('C-Bus Status (Test): 254/56/16 ON (100%)')
-            );
+            if (debugSuffix) {
+                expect(mockLogger.debug).toHaveBeenCalledWith(
+                    expect.stringContaining(`C-Bus Status (Test): 254/56/16 ${debugSuffix}`)
+                );
+            }
         });
 
-        it('should publish lighting device OFF event with state and level', () => {
-            const eventData = 'lighting off 254/56/16';
-            const event = new CBusEvent(eventData);
-            
-            eventPublisher.publishEvent(event, '(Test)');
-
-            expect(mockPublishFn).toHaveBeenCalledTimes(2);
-            
-            // Check state message
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/16/state',
-                'OFF',
-                mockMqttOptions
-            );
-            
-            // Check level message (OFF events assume 0%)
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/16/level',
-                '0',
-                mockMqttOptions
-            );
-
-            expect(mockLogger.debug).toHaveBeenCalledWith(
-                expect.stringContaining('C-Bus Status (Test): 254/56/16 OFF (0%)')
-            );
-        });
-
-        it('should publish lighting device ramp event with correct level percentage', () => {
-            const eventData = 'lighting ramp 254/56/16 128'; // 128/255 = 50%
-            const event = new CBusEvent(eventData);
-            
-            eventPublisher.publishEvent(event, '(Test)');
-
-            expect(mockPublishFn).toHaveBeenCalledTimes(2);
-            
-            // Check state message (ON because level > 0)
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/16/state',
-                'ON',
-                mockMqttOptions
-            );
-            
-            // Check level message (50% of 255)
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/16/level',
-                '50',
-                mockMqttOptions
-            );
-        });
-
-        it('should publish PIR sensor event with state only (no level)', () => {
-            // Create PIR sensor event - app 202 (PIR app ID)
-            const eventData = 'security on 254/202/16'; // PIR motion detected
-            const event = new CBusEvent(eventData);
-            
+        it.each([
+            ['on', 'ON'],
+            ['off', 'OFF'],
+        ])('should publish PIR %s with state only (no level)', (action, state) => {
+            const event = new CBusEvent(`security ${action} 254/202/16`);
             eventPublisher.publishEvent(event, '(Test)');
 
             expect(mockPublishFn).toHaveBeenCalledTimes(1);
-            
-            // Check state message only
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/202/16/state',
-                'ON',
-                mockMqttOptions
+                'cbus/read/254/202/16/state', state, mockMqttOptions
             );
-
-            expect(mockLogger.debug).toHaveBeenCalledWith(
-                expect.stringContaining('C-Bus Status (Test): 254/202/16 ON')
-            );
-            expect(mockLogger.debug).toHaveBeenCalledWith(
-                expect.not.stringContaining('(%)')
-            );
-        });
-
-        it('should publish PIR sensor OFF event correctly', () => {
-            // Create PIR sensor OFF event
-            const eventData = 'security off 254/202/16'; // PIR motion cleared
-            const event = new CBusEvent(eventData);
-            
-            eventPublisher.publishEvent(event, '(Test)');
-
-            expect(mockPublishFn).toHaveBeenCalledTimes(1);
-            
-            // Check state message only
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/202/16/state',
-                'OFF',
-                mockMqttOptions
-            );
+            if (action === 'on') {
+                expect(mockLogger.debug).toHaveBeenCalledWith(
+                    expect.stringContaining('C-Bus Status (Test): 254/202/16 ON')
+                );
+                expect(mockLogger.debug).toHaveBeenCalledWith(
+                    expect.not.stringContaining('(%)')
+                );
+            }
         });
 
         it('should handle events without source parameter', () => {
@@ -266,37 +192,30 @@ describe('EventPublisher', () => {
             );
         });
 
-        it('should round level percentages correctly', () => {
-            // Test various level values to ensure proper rounding
-            const testCases = [
-                { level: 1, expectedPercent: '0' },    // 1/255 = 0.39% -> 0%
-                { level: 2, expectedPercent: '1' },    // 2/255 = 0.78% -> 1%
-                { level: 127, expectedPercent: '50' }, // 127/255 = 49.8% -> 50%
-                { level: 128, expectedPercent: '50' }, // 128/255 = 50.2% -> 50%
-                { level: 254, expectedPercent: '100' }, // 254/255 = 99.6% -> 100%
-                { level: 255, expectedPercent: '100' }  // 255/255 = 100% -> 100%
-            ];
+        it.each([
+            [1, '0'],    // 1/255 = 0.39% → 0%
+            [2, '1'],    // 2/255 = 0.78% → 1%
+            [127, '50'], // 127/255 = 49.8% → 50%
+            [128, '50'], // 128/255 = 50.2% → 50%
+            [254, '100'],
+            [255, '100'],
+        ])('should round level %i to %s%%', (level, expectedPercent) => {
+            const mockEvent = {
+                isValid: () => true,
+                getNetwork: () => '254',
+                getApplication: () => '56',
+                getGroup: () => '16',
+                getLevel: () => level,
+                getAction: () => 'ramp'
+            };
 
-            testCases.forEach(({ level, expectedPercent }) => {
-                mockPublishFn.mockClear();
-                
-                const mockEvent = {
-                    isValid: () => true,
-                    getNetwork: () => '254',
-                    getApplication: () => '56',
-                    getGroup: () => '16',
-                    getLevel: () => level,
-                    getAction: () => 'ramp'
-                };
-                
-                eventPublisher.publishEvent(mockEvent);
-                
-                expect(mockPublishFn).toHaveBeenCalledWith(
-                    'cbus/read/254/56/16/level',
-                    expectedPercent,
-                    mockMqttOptions
-                );
-            });
+            eventPublisher.publishEvent(mockEvent);
+
+            expect(mockPublishFn).toHaveBeenCalledWith(
+                'cbus/read/254/56/16/level',
+                expectedPercent,
+                mockMqttOptions
+            );
         });
 
         it('should publish directly without throttle delay', () => {
@@ -310,103 +229,39 @@ describe('EventPublisher', () => {
     });
 
     describe('Cover position publishing', () => {
-        it('should publish cover event with state, level, and position', () => {
+        it.each([
+            [128, 'ON', '50', 3],
+            [0, 'OFF', '0', 3],
+            [255, 'ON', '100', 3],
+        ])('cover level=%i → state=%s position=%s (%i publishes)', (rawLevel, state, position, times) => {
             const mockEvent = {
                 isValid: () => true,
                 getNetwork: () => '254',
-                getApplication: () => '203', // Cover app ID
+                getApplication: () => '203',
                 getGroup: () => '1',
-                getLevel: () => 128, // 50%
+                getLevel: () => rawLevel,
                 getAction: () => 'ramp'
             };
-            
+
             eventPublisher.publishEvent(mockEvent, '(Test)');
 
-            // Should publish 3 messages: state, level, and position
-            expect(mockPublishFn).toHaveBeenCalledTimes(3);
-            
-            // Check state message
+            expect(mockPublishFn).toHaveBeenCalledTimes(times);
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/203/1/state',
-                'ON',
-                mockMqttOptions
+                'cbus/read/254/203/1/state', state, mockMqttOptions
             );
-            
-            // Check level message
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/203/1/level',
-                '50',
-                mockMqttOptions
+                'cbus/read/254/203/1/level', position, mockMqttOptions
             );
-            
-            // Check position message
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/203/1/position',
-                '50',
-                mockMqttOptions
-            );
-        });
-
-        it('should publish cover closed state correctly', () => {
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '203',
-                getGroup: () => '1',
-                getLevel: () => 0, // 0% - closed
-                getAction: () => 'ramp'
-            };
-            
-            eventPublisher.publishEvent(mockEvent);
-
-            // Check state message - should be OFF (closed)
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/203/1/state',
-                'OFF',
-                mockMqttOptions
-            );
-            
-            // Check position message
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/203/1/position',
-                '0',
-                mockMqttOptions
-            );
-        });
-
-        it('should publish cover fully open state correctly', () => {
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '203',
-                getGroup: () => '1',
-                getLevel: () => 255, // 100% - fully open
-                getAction: () => 'ramp'
-            };
-            
-            eventPublisher.publishEvent(mockEvent);
-
-            // Check state message - should be ON (open)
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/203/1/state',
-                'ON',
-                mockMqttOptions
-            );
-            
-            // Check position message
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/203/1/position',
-                '100',
-                mockMqttOptions
+                'cbus/read/254/203/1/position', position, mockMqttOptions
             );
         });
 
         it('should not publish position for non-cover devices', () => {
-            // Regular lighting device (not a cover)
             const mockEvent = {
                 isValid: () => true,
                 getNetwork: () => '254',
-                getApplication: () => '56', // Lighting app, not cover
+                getApplication: () => '56',
                 getGroup: () => '1',
                 getLevel: () => 128,
                 getAction: () => 'ramp'
@@ -414,14 +269,8 @@ describe('EventPublisher', () => {
 
             eventPublisher.publishEvent(mockEvent);
 
-            // Should only publish state and level (2 messages), not position
             expect(mockPublishFn).toHaveBeenCalledTimes(2);
-
-            // Verify no position topic was published
-            const positionCall = mockPublishFn.mock.calls.find(
-                call => call[0].endsWith('/position')
-            );
-            expect(positionCall).toBeUndefined();
+            expect(mockPublishFn.mock.calls.find(call => call[0].endsWith('/position'))).toBeUndefined();
         });
     });
 
@@ -484,7 +333,10 @@ describe('EventPublisher', () => {
             };
         });
 
-        it('should publish position for a lighting group type-overridden to cover', () => {
+        it.each([
+            ['0', 128, 'ON', '50'],
+            ['21', 0, 'OFF', '0'],
+        ])('should publish position for lighting group %s type-overridden to cover', (group, level, state, percent) => {
             const publisher = new EventPublisher({
                 settings: mockSettings,
                 publishFn: mockPublishFn,
@@ -493,30 +345,30 @@ describe('EventPublisher', () => {
                 logger: mockLogger
             });
 
-            const mockEvent = {
+            publisher.publishEvent({
                 isValid: () => true,
                 getNetwork: () => '254',
                 getApplication: () => '56',
-                getGroup: () => '0',
-                getLevel: () => 128,
+                getGroup: () => group,
+                getLevel: () => level,
                 getAction: () => 'ramp'
-            };
+            });
 
-            publisher.publishEvent(mockEvent);
-
-            expect(mockPublishFn).toHaveBeenCalledTimes(3);
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/0/state', 'ON', mockMqttOptions
+                `cbus/read/254/56/${group}/state`, state, mockMqttOptions
             );
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/0/level', '50', mockMqttOptions
+                `cbus/read/254/56/${group}/level`, percent, mockMqttOptions
             );
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/0/position', '50', mockMqttOptions
+                `cbus/read/254/56/${group}/position`, percent, mockMqttOptions
             );
         });
 
-        it('should use cover state logic for type-overridden covers', () => {
+        it.each([
+            ['16', 'cover-unrelated lighting group'],
+            ['6', 'switch type override'],
+        ])('should not publish position for group %s (%s)', (group) => {
             const publisher = new EventPublisher({
                 settings: mockSettings,
                 publishFn: mockPublishFn,
@@ -525,77 +377,17 @@ describe('EventPublisher', () => {
                 logger: mockLogger
             });
 
-            const mockEvent = {
+            publisher.publishEvent({
                 isValid: () => true,
                 getNetwork: () => '254',
                 getApplication: () => '56',
-                getGroup: () => '21',
-                getLevel: () => 0,
-                getAction: () => 'ramp'
-            };
-
-            publisher.publishEvent(mockEvent);
-
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/21/state', 'OFF', mockMqttOptions
-            );
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/56/21/position', '0', mockMqttOptions
-            );
-        });
-
-        it('should not publish position for a lighting group not overridden to cover', () => {
-            const publisher = new EventPublisher({
-                settings: mockSettings,
-                publishFn: mockPublishFn,
-                mqttOptions: mockMqttOptions,
-                labelLoader: mockLabelLoader,
-                logger: mockLogger
+                getGroup: () => group,
+                getLevel: () => group === '6' ? 255 : 128,
+                getAction: () => group === '6' ? 'on' : 'ramp'
             });
-
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '56',
-                getGroup: () => '16',
-                getLevel: () => 128,
-                getAction: () => 'ramp'
-            };
-
-            publisher.publishEvent(mockEvent);
 
             expect(mockPublishFn).toHaveBeenCalledTimes(2);
-            const positionCall = mockPublishFn.mock.calls.find(
-                call => call[0].endsWith('/position')
-            );
-            expect(positionCall).toBeUndefined();
-        });
-
-        it('should not publish position for a switch type override', () => {
-            const publisher = new EventPublisher({
-                settings: mockSettings,
-                publishFn: mockPublishFn,
-                mqttOptions: mockMqttOptions,
-                labelLoader: mockLabelLoader,
-                logger: mockLogger
-            });
-
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '56',
-                getGroup: () => '6',
-                getLevel: () => 255,
-                getAction: () => 'on'
-            };
-
-            publisher.publishEvent(mockEvent);
-
-            expect(mockPublishFn).toHaveBeenCalledTimes(2);
-            const positionCall = mockPublishFn.mock.calls.find(
-                call => call[0].endsWith('/position')
-            );
-            expect(positionCall).toBeUndefined();
+            expect(mockPublishFn.mock.calls.find(c => c[0].endsWith('/position'))).toBeUndefined();
         });
 
         it('should fall back to app-ID-only check when labelLoader is null', () => {
@@ -606,23 +398,17 @@ describe('EventPublisher', () => {
                 logger: mockLogger
             });
 
-            const mockEvent = {
+            publisher.publishEvent({
                 isValid: () => true,
                 getNetwork: () => '254',
                 getApplication: () => '56',
                 getGroup: () => '0',
                 getLevel: () => 128,
                 getAction: () => 'ramp'
-            };
+            });
 
-            publisher.publishEvent(mockEvent);
-
-            // Without labelLoader, group 0 on app 56 is a regular light (2 messages)
             expect(mockPublishFn).toHaveBeenCalledTimes(2);
-            const positionCall = mockPublishFn.mock.calls.find(
-                call => call[0].endsWith('/position')
-            );
-            expect(positionCall).toBeUndefined();
+            expect(mockPublishFn.mock.calls.find(c => c[0].endsWith('/position'))).toBeUndefined();
         });
 
         it('should still detect covers by app ID even with labelLoader present', () => {
@@ -634,16 +420,14 @@ describe('EventPublisher', () => {
                 logger: mockLogger
             });
 
-            const mockEvent = {
+            publisher.publishEvent({
                 isValid: () => true,
                 getNetwork: () => '254',
                 getApplication: () => '203',
                 getGroup: () => '5',
                 getLevel: () => 128,
                 getAction: () => 'ramp'
-            };
-
-            publisher.publishEvent(mockEvent);
+            });
 
             expect(mockPublishFn).toHaveBeenCalledTimes(3);
             expect(mockPublishFn).toHaveBeenCalledWith(
@@ -966,13 +750,16 @@ describe('EventPublisher', () => {
             });
         });
 
-        it('should publish trigger event with JSON event payload to event topic', () => {
+        it.each([
+            [255, JSON.stringify({ event_type: 'trigger', level: 255 }), '1'],
+            [null, JSON.stringify({ event_type: 'trigger' }), '2'],
+        ])('should publish trigger event (level=%s) to event topic', (level, payload, group) => {
             const mockEvent = {
                 isValid: () => true,
                 getNetwork: () => '254',
                 getApplication: () => '205',
-                getGroup: () => '1',
-                getLevel: () => 255,
+                getGroup: () => group,
+                getLevel: () => level,
                 getAction: () => 'on'
             };
 
@@ -980,28 +767,8 @@ describe('EventPublisher', () => {
 
             expect(mockPublishFn).toHaveBeenCalledTimes(1);
             expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/205/1/event',
-                JSON.stringify({ event_type: 'trigger', level: 255 }),
-                { ...mockMqttOptions, retain: false }
-            );
-        });
-
-        it('should publish trigger event without level when level is null', () => {
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '205',
-                getGroup: () => '2',
-                getLevel: () => null,
-                getAction: () => 'on'
-            };
-
-            triggerPublisher.publishEvent(mockEvent, '(Test)');
-
-            expect(mockPublishFn).toHaveBeenCalledTimes(1);
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/205/2/event',
-                JSON.stringify({ event_type: 'trigger' }),
+                `cbus/read/254/205/${group}/event`,
+                payload,
                 { ...mockMqttOptions, retain: false }
             );
         });
@@ -1018,20 +785,16 @@ describe('EventPublisher', () => {
 
             triggerPublisher.publishEvent(mockEvent);
 
-            // Only the event topic - no state, level, or position
             expect(mockPublishFn).toHaveBeenCalledTimes(1);
             const topic = mockPublishFn.mock.calls[0][0];
             expect(topic).toBe('cbus/read/254/205/3/event');
-            expect(topic).not.toContain('/state');
-            expect(topic).not.toContain('/level');
-            expect(topic).not.toContain('/position');
         });
 
         it('should not treat non-trigger app events as trigger events', () => {
             const mockEvent = {
                 isValid: () => true,
                 getNetwork: () => '254',
-                getApplication: () => '56', // lighting app
+                getApplication: () => '56',
                 getGroup: () => '1',
                 getLevel: () => 255,
                 getAction: () => 'on'
@@ -1039,7 +802,6 @@ describe('EventPublisher', () => {
 
             triggerPublisher.publishEvent(mockEvent);
 
-            // Should publish state and level (not event topic)
             expect(mockPublishFn).toHaveBeenCalledTimes(2);
             expect(mockPublishFn).not.toHaveBeenCalledWith(
                 expect.stringContaining('/event'),
@@ -1309,61 +1071,26 @@ describe('EventPublisher', () => {
             });
         });
 
-        it('should publish tilt event to the tilt topic with correct 0-100 value', () => {
+        it.each([
+            [128, 'ramp', '50'],
+            [255, 'on', '100'],
+            [0, 'off', '0'],
+            [null, 'on', '100'], // no level + action on → 100%
+        ])('level=%j action=%s → tilt=%s', (rawLevel, action, tilt) => {
             const mockEvent = {
                 isValid: () => true,
                 getNetwork: () => '254',
                 getApplication: () => '204',
                 getGroup: () => '5',
-                getLevel: () => 128,
-                getAction: () => 'ramp'
-            };
-
-            tiltPublisher.publishEvent(mockEvent);
-
-            // 128 / 255 * 100 = ~50%
-            expect(mockPublishFn).toHaveBeenCalledTimes(1);
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/204/5/tilt',
-                '50',
-                mockMqttOptions
-            );
-        });
-
-        it('should publish tilt=100 for full-level event', () => {
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '204',
-                getGroup: () => '5',
-                getLevel: () => 255,
-                getAction: () => 'on'
+                getLevel: () => rawLevel,
+                getAction: () => action
             };
 
             tiltPublisher.publishEvent(mockEvent);
 
             expect(mockPublishFn).toHaveBeenCalledWith(
                 'cbus/read/254/204/5/tilt',
-                '100',
-                mockMqttOptions
-            );
-        });
-
-        it('should publish tilt=0 for off event', () => {
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '204',
-                getGroup: () => '5',
-                getLevel: () => 0,
-                getAction: () => 'off'
-            };
-
-            tiltPublisher.publishEvent(mockEvent);
-
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/204/5/tilt',
-                '0',
+                tilt,
                 mockMqttOptions
             );
         });
@@ -1391,7 +1118,7 @@ describe('EventPublisher', () => {
             const mockEvent = {
                 isValid: () => true,
                 getNetwork: () => '254',
-                getApplication: () => '203', // cover app, not tilt app
+                getApplication: () => '203',
                 getGroup: () => '5',
                 getLevel: () => 128,
                 getAction: () => 'ramp'
@@ -1399,30 +1126,10 @@ describe('EventPublisher', () => {
 
             tiltPublisher.publishEvent(mockEvent);
 
-            // Cover app event — should publish state, level, position (not tilt)
             expect(mockPublishFn).not.toHaveBeenCalledWith(
                 expect.stringContaining('/tilt'),
                 expect.anything(),
                 expect.anything()
-            );
-        });
-
-        it('should infer 100% tilt when no level and action is on', () => {
-            const mockEvent = {
-                isValid: () => true,
-                getNetwork: () => '254',
-                getApplication: () => '204',
-                getGroup: () => '5',
-                getLevel: () => null,
-                getAction: () => 'on'
-            };
-
-            tiltPublisher.publishEvent(mockEvent);
-
-            expect(mockPublishFn).toHaveBeenCalledWith(
-                'cbus/read/254/204/5/tilt',
-                '100',
-                mockMqttOptions
             );
         });
     });

--- a/tests/eventPublisher.test.js
+++ b/tests/eventPublisher.test.js
@@ -661,6 +661,32 @@ describe('EventPublisher', () => {
             jest.useRealTimers();
         });
 
+        it('preserves eventPublishDedupWindowMs of 0 (dedup disabled)', () => {
+            const publisher = new EventPublisher({
+                settings: {
+                    ...mockSettings,
+                    eventPublishDedupWindowMs: 0
+                },
+                publishFn: mockPublishFn,
+                mqttOptions: mockMqttOptions,
+                logger: mockLogger
+            });
+            expect(publisher.eventPublishDedupWindowMs).toBe(0);
+        });
+
+        it('clamps zero eventPublishDedupMaxEntries to the 100-entry floor', () => {
+            const publisher = new EventPublisher({
+                settings: {
+                    ...mockSettings,
+                    eventPublishDedupMaxEntries: 0
+                },
+                publishFn: mockPublishFn,
+                mqttOptions: mockMqttOptions,
+                logger: mockLogger
+            });
+            expect(publisher.eventPublishDedupMaxEntries).toBe(100);
+        });
+
         it('should suppress unchanged payloads within dedup window', () => {
             const publisher = new EventPublisher({
                 settings: {

--- a/tests/haBridgeDiagnostics.test.js
+++ b/tests/haBridgeDiagnostics.test.js
@@ -119,6 +119,25 @@ describe('HaBridgeDiagnostics', () => {
         expect(publishFn).toHaveBeenCalled();
     });
 
+    test('clamps a zero diagnostics interval to the 10s floor', () => {
+        jest.useFakeTimers();
+        diagnostics = new HaBridgeDiagnostics(
+            { ...settings, ha_bridge_diagnostics_interval_sec: 0 },
+            publishFn,
+            getStatusFn
+        );
+        diagnostics.start();
+        publishFn.mockClear();
+
+        jest.advanceTimersByTime(9999);
+        expect(publishFn).not.toHaveBeenCalled();
+        jest.advanceTimersByTime(1);
+        expect(publishFn).toHaveBeenCalled();
+
+        diagnostics.stop();
+        jest.useRealTimers();
+    });
+
     test('consolidated stats topic contains correct JSON structure', () => {
         diagnostics.publishNow('test');
 

--- a/tests/labelLoader.test.js
+++ b/tests/labelLoader.test.js
@@ -494,6 +494,109 @@ describe('LabelLoader', () => {
             loader.unwatch();
         });
     });
+
+    describe('watch callback debounce and self-write grace (fake timers)', () => {
+        const { EventEmitter } = require('events');
+        const DEBOUNCE_MS = 500;
+        const GRACE_MS = 1000;
+
+        let watchListener;
+        let mockWatcher;
+        let loader;
+
+        beforeEach(() => {
+            jest.useFakeTimers();
+            fs.writeFileSync(labelFile, JSON.stringify({
+                version: 1,
+                labels: { '254/56/10': 'Original' }
+            }));
+
+            watchListener = null;
+            mockWatcher = new EventEmitter();
+            mockWatcher.close = jest.fn();
+            jest.spyOn(fs, 'watch').mockImplementation((_dir, listener) => {
+                watchListener = listener;
+                return mockWatcher;
+            });
+
+            loader = new LabelLoader(labelFile, {
+                labelWatchDebounceMs: DEBOUNCE_MS,
+                labelWatchSelfWriteGraceMs: GRACE_MS
+            });
+            loader.load();
+            loader.watch();
+            expect(watchListener).toEqual(expect.any(Function));
+        });
+
+        afterEach(() => {
+            loader.unwatch();
+            jest.useRealTimers();
+        });
+
+        it('debounces fs.watch events then reloads and emits labels-changed', () => {
+            const handler = jest.fn();
+            loader.on('labels-changed', handler);
+
+            fs.writeFileSync(labelFile, JSON.stringify({
+                version: 1,
+                labels: { '254/56/10': 'External Edit' }
+            }));
+
+            watchListener('change', path.basename(labelFile));
+            expect(handler).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(DEBOUNCE_MS - 1);
+            expect(handler).not.toHaveBeenCalled();
+
+            // A second event inside the window must reset the timer, not queue
+            // a second reload.
+            watchListener('change', path.basename(labelFile));
+            jest.advanceTimersByTime(DEBOUNCE_MS - 1);
+            expect(handler).not.toHaveBeenCalled();
+
+            jest.advanceTimersByTime(1);
+            expect(handler).toHaveBeenCalledTimes(1);
+            expect(handler.mock.calls[0][0].labels.get('254/56/10')).toBe('External Edit');
+            expect(loader.getLabels().get('254/56/10')).toBe('External Edit');
+        });
+
+        it('ignores watch events inside the self-write grace window after save()', () => {
+            const handler = jest.fn();
+            loader.on('labels-changed', handler);
+
+            // save() emits once synchronously and stamps _lastSaveTime
+            loader.save({ '254/56/10': 'Via Save' });
+            expect(handler).toHaveBeenCalledTimes(1);
+
+            // Watcher fires for our own write — still within grace → ignored
+            watchListener('change', path.basename(labelFile));
+            jest.advanceTimersByTime(DEBOUNCE_MS);
+            expect(handler).toHaveBeenCalledTimes(1);
+
+            // Past grace: an external change must still reload
+            jest.advanceTimersByTime(GRACE_MS);
+            fs.writeFileSync(labelFile, JSON.stringify({
+                version: 1,
+                labels: { '254/56/10': 'After Grace' }
+            }));
+            watchListener('change', path.basename(labelFile));
+            jest.advanceTimersByTime(DEBOUNCE_MS);
+            expect(handler).toHaveBeenCalledTimes(2);
+            expect(handler.mock.calls[1][0].labels.get('254/56/10')).toBe('After Grace');
+        });
+
+        it('ignores watch events for unrelated filenames', () => {
+            const onChanged = jest.spyOn(loader, '_onFileChanged');
+            watchListener('change', 'other-file.json');
+            jest.advanceTimersByTime(DEBOUNCE_MS);
+            expect(onChanged).not.toHaveBeenCalled();
+        });
+
+        it('logs watcher error events without throwing', () => {
+            expect(() => mockWatcher.emit('error', new Error('watch failed'))).not.toThrow();
+            expect(console.warn).toHaveBeenCalled();
+        });
+    });
 });
 
 describe('reload robustness (transient file absence, e.g. HA backup)', () => {

--- a/tests/serialDeviceRecovery.test.js
+++ b/tests/serialDeviceRecovery.test.js
@@ -552,9 +552,10 @@ describe('SerialDeviceRecovery', () => {
 
         it('will not let a zero timeout mean "wait forever"', () => {
             // execFileSync reads timeout: 0 as no timeout at all, which would
-            // hand a wedged helper the whole bridge.
+            // hand a wedged helper the whole bridge. 0 now clamps to the 1s
+            // floor (not the schema default) so the bound stays load-bearing.
             const zero = new SerialDeviceRecovery({ settings: { ...SETTINGS, serialRecoveryTimeoutMs: 0 } });
-            expect(zero._timeoutMs()).toBe(defaultSettings.serialRecoveryTimeoutMs);
+            expect(zero._timeoutMs()).toBe(1000);
 
             const tiny = new SerialDeviceRecovery({ settings: { ...SETTINGS, serialRecoveryTimeoutMs: 5 } });
             expect(tiny._timeoutMs()).toBe(1000);

--- a/tests/staleDeviceDetector.test.js
+++ b/tests/staleDeviceDetector.test.js
@@ -321,5 +321,19 @@ describe('StaleDeviceDetector', () => {
 
             detector.stop();
         });
+
+        it('clamps a zero check interval to the 60s floor', () => {
+            deviceStateManager.getAllLastSeen.mockReturnValue(new Map());
+            const detector = makeDetector({ stale_device_check_interval_sec: 0 });
+            detector.start();
+            publishFn.mockClear();
+
+            jest.advanceTimersByTime(59999);
+            expect(publishFn).not.toHaveBeenCalled();
+            jest.advanceTimersByTime(1);
+            expect(publishFn).toHaveBeenCalled();
+
+            detector.stop();
+        });
     });
 });

--- a/tests/stateResyncCoordinator.test.js
+++ b/tests/stateResyncCoordinator.test.js
@@ -178,4 +178,13 @@ describe('StateResyncCoordinator', () => {
             expect(commandQueue.add).not.toHaveBeenCalled();
         });
     });
+
+    describe('debounceMs of 0', () => {
+        it('preserves 0 as immediate (does not fall back to the schema default)', () => {
+            settings.stateResyncDebounceMs = 0;
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(0);
+            expect(commandQueue.add).toHaveBeenCalled();
+        });
+    });
 });

--- a/tests/webServer.test.js
+++ b/tests/webServer.test.js
@@ -630,6 +630,59 @@ describe('WebServer', () => {
             expect(s._apiAuth.isAuthorized(mkReq({}))).toBe(false);
         });
 
+        it('trims configured API keys so padded secrets still authenticate', () => {
+            const s = new WebServer({
+                port: 0,
+                labelLoader,
+                getStatus: () => ({}),
+                apiKey: '  secret-key  '
+            });
+            expect(s.apiKey).toBe('secret-key');
+            expect(s._apiAuth.apiKey).toBe('secret-key');
+            expect(s._apiAuth.isAuthorized(mkReq({ 'x-api-key': 'secret-key' }))).toBe(true);
+            expect(s._apiAuth.isAuthorized(mkReq({ authorization: 'Bearer secret-key' }))).toBe(true);
+        });
+
+        it('treats whitespace-only API keys as unset (401 on mutation without ingress)', async () => {
+            protectedServer = new WebServer({
+                port: 0,
+                labelLoader,
+                apiKey: '   ',
+                getStatus: () => ({})
+            });
+            expect(protectedServer.apiKey).toBeNull();
+            await protectedServer.start();
+            protectedPort = protectedServer._server.address().port;
+
+            const res = await new Promise((resolve, reject) => {
+                const req = http.request({
+                    hostname: '127.0.0.1',
+                    port: protectedPort,
+                    path: '/api/labels',
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' }
+                }, (response) => {
+                    let data = '';
+                    response.on('data', (chunk) => { data += chunk; });
+                    response.on('end', () => resolve({ status: response.statusCode, body: JSON.parse(data) }));
+                });
+                req.on('error', reject);
+                req.write(JSON.stringify({ '254/56/10': 'Patched' }));
+                req.end();
+            });
+            expect(res.status).toBe(401);
+        });
+
+        it('warns once when a configured API key trims to empty', () => {
+            const warnSpy = jest.spyOn(console, 'warn');
+            const blank = new WebServer({ port: 0, labelLoader, getStatus: () => ({}), apiKey: '   ' });
+            expect(blank.apiKey).toBeNull();
+            const blankWarnings = warnSpy.mock.calls.filter(
+                (args) => typeof args[0] === 'string' && args[0].includes('empty after trimming')
+            );
+            expect(blankWarnings).toHaveLength(1);
+        });
+
         it('should honor maxBodySizeBytes override for body-size enforcement', () => {
             const tiny = new WebServer({
                 port: 0,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Direct push to `master` was rejected (protected branch, 9 required checks). This PR lands the six leftover items as **separate commits**. Please **rebase-merge** (not squash) so they stay separate on `master`. No version or changelog bump.

## Changes

1. Finish `resolveSetting` for remaining numeric tunables. `resolveClampedSetting` now falls back to the schema default when the value is not finite (typos no longer produce `NaN` timers/caches).
2. Trim web API keys and treat blank/whitespace as unset so the add-on empty password field cannot authenticate as a secret.
3. Tests for connection-pool `execute()` spreading and LabelLoader `fs.watch` debounce (two events, one reload).
4. Cap actual inflated zip entry size and XML size/token count on label import. Token default is 2e6 so large DLT-tagged Toolkit exports still parse; constructor override for tests.
5. Share discovery payload assembly for tree entities (`_finishTreeEntity` / `_publishDiscoveryPayload`).
6. Table-drive MQTT event publishes (`EVENT_KIND_HANDLERS`), same pattern as readings.

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification

## Checklist

- [ ] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [ ] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

