### PR TITLE
Discovery cleanup, import hardening, credential trim, lighting echo (no release)

### DIFF
--- a/src/cbusProjectParser.js
+++ b/src/cbusProjectParser.js
@@ -337,10 +337,14 @@ class CbusProjectParser {
             }
         }
         return new Promise((resolve, reject) => {
-            parseString(xmlString, { explicitArray: false, ignoreAttrs: false, mergeAttrs: true }, (err, result) => {
-                if (err) reject(new Error(`XML parse error: ${err.message}`));
-                else resolve(result);
-            });
+            try {
+                parseString(xmlString, { explicitArray: false, ignoreAttrs: false, mergeAttrs: true }, (err, result) => {
+                    if (err) reject(new Error(`XML parse error: ${err.message}`));
+                    else resolve(result);
+                });
+            } catch (e) {
+                reject(new Error(`XML parse error: ${e && e.message ? e.message : e}`));
+            }
         });
     }
 

--- a/src/cbusProjectParser.js
+++ b/src/cbusProjectParser.js
@@ -168,6 +168,7 @@ class CbusProjectParser {
         let xmlEntry = fileEntries.find(e => e.entryName.toLowerCase().endsWith('.xml'));
         if (!xmlEntry) {
             xmlEntry = fileEntries.find(e => {
+                if (!_isSafeZipEntryName(e.entryName)) return false;
                 try {
                     // adm-zip fully inflates on getData(); check actual length
                     // immediately, then sniff only the first 512 bytes of that
@@ -191,6 +192,7 @@ class CbusProjectParser {
 
         // No XML — newer Toolkit (1.17.x) packs a SQLite project database.
         const dbEntry = fileEntries.find(e => {
+            if (!_isSafeZipEntryName(e.entryName)) return false;
             if (e.entryName.toLowerCase().endsWith('.db')) return true;
             try {
                 const data = this._getEntryDataWithinCap(e);

--- a/src/cgateConnection.js
+++ b/src/cgateConnection.js
@@ -9,7 +9,7 @@ const {
     CGATE_CMD_LOGIN, 
     NEWLINE 
 } = require('./constants');
-const { isValidCgateUsername, isValidCgatePassword } = require('./config/validationRules');
+const { isValidCgateUsername, isValidCgatePassword, normalizeOptionalSecret } = require('./config/validationRules');
 const { looksLikeTlsRecord } = require('./utils');
 
 class CgateConnection extends EventEmitter {
@@ -328,18 +328,17 @@ class CgateConnection extends EventEmitter {
                 this.logger.info(`C-Gate Sent: ${CGATE_CMD_EVENT_MODE_L6}`);
                 
                 // 2. Send LOGIN if credentials provided
-                const user = this.settings.cgateusername;
-                const pass = this.settings.cgatepassword;
-                if (user && typeof user === 'string' && user.trim() !== '' && typeof pass === 'string') {
-                    const trimmedUser = user.trim();
-                    if (!isValidCgateUsername(trimmedUser) || !isValidCgatePassword(pass)) {
+                const user = normalizeOptionalSecret(this.settings.cgateusername);
+                const pass = normalizeOptionalSecret(this.settings.cgatepassword);
+                if (user && typeof pass === 'string') {
+                    if (!isValidCgateUsername(user) || !isValidCgatePassword(pass)) {
                         this.logger.error(
                             'Refusing to send LOGIN: username/password contain unsafe characters '
                             + '(spaces, newlines, or non-printable). Fix cgateusername/cgatepassword in settings.'
                         );
                     } else {
-                        const loginCmd = `${CGATE_CMD_LOGIN} ${trimmedUser} ${pass}${NEWLINE}`;
-                        this.logger.info(`Sending LOGIN command for user '${trimmedUser}'...`);
+                        const loginCmd = `${CGATE_CMD_LOGIN} ${user} ${pass}${NEWLINE}`;
+                        this.logger.info(`Sending LOGIN command for user '${user}'...`);
                         this.socket.write(loginCmd);
                     }
                 }

--- a/src/config/ConfigLoader.js
+++ b/src/config/ConfigLoader.js
@@ -4,7 +4,7 @@ const { Logger } = require('../logger');
 const EnvironmentDetector = require('./EnvironmentDetector');
 const { listKnownConfigKeys, listSettingAliases, getSchemaEntry } = require('./schema');
 const { DEFAULT_ADDON_LABEL_FILE, LEGACY_ADDON_LABEL_FILE, DEFAULT_ADDON_DATA_LABEL_FILE } = require('../constants');
-const { isPortInRange, isValidCgateProjectName, isValidCgateUsername, isValidCgatePassword } = require('./validationRules');
+const { isPortInRange, isValidCgateProjectName, isValidCgateUsername, isValidCgatePassword, normalizeOptionalSecret } = require('./validationRules');
 const { applyAddonOptionMap } = require('./addonOptionMap');
 
 const DEFAULT_MQTT_VALUES = ['core-mosquitto:1883', '127.0.0.1:1883', undefined, null, ''];
@@ -269,6 +269,7 @@ class ConfigLoader {
             config.web_allowed_origins = options.web_allowed_origins.filter((origin) => typeof origin === 'string' && origin.trim() !== '');
         }
 
+        this._trimSecretFields(config);
         return config;
     }
 
@@ -347,6 +348,7 @@ class ConfigLoader {
             config.cbus_aircon_control_enabled = config.cbus_aircon_control_enabled.toLowerCase() === 'true';
         }
 
+        this._trimSecretFields(config);
         return config;
     }
 
@@ -457,6 +459,7 @@ class ConfigLoader {
      * @returns {Promise<Object>} settings with MQTT fields populated (mutated in place)
      */
     async applyMqttAutoDetection(settings) {
+        this._trimSecretFields(settings);
         const mqttConfig = await this.detectMqttConfig();
         if (!mqttConfig) {
             const hasDefaultBroker = DEFAULT_MQTT_VALUES.includes(settings.mqtt);
@@ -486,6 +489,21 @@ class ConfigLoader {
         }
 
         return settings;
+    }
+
+    /**
+     * Trim MQTT/C-Gate username and password fields. Blank after trim is
+     * treated as unset so a padded HA password field cannot become a secret
+     * (same rule as web_api_key).
+     * @param {Object} settings
+     * @private
+     */
+    _trimSecretFields(settings) {
+        if (!settings || typeof settings !== 'object') return;
+        for (const key of ['mqttusername', 'mqttpassword', 'cgateusername', 'cgatepassword']) {
+            if (!Object.prototype.hasOwnProperty.call(settings, key)) continue;
+            settings[key] = normalizeOptionalSecret(settings[key]);
+        }
     }
 
     /**

--- a/src/config/validationRules.js
+++ b/src/config/validationRules.js
@@ -64,9 +64,24 @@ function isValidCgatePassword(pass) {
     return typeof pass === 'string' && CGATE_PASSWORD_PATTERN.test(pass);
 }
 
+/**
+ * Trim a configured secret. Blank after trim is unset (null), matching
+ * web_api_key handling: HA password fields often submit "" or spaces.
+ *
+ * @param {unknown} raw
+ * @returns {string|null|*} null when blank string; unchanged when not a string
+ */
+function normalizeOptionalSecret(raw) {
+    if (raw === null || raw === undefined) return raw;
+    if (typeof raw !== 'string') return raw;
+    const trimmed = raw.trim();
+    return trimmed === '' ? null : trimmed;
+}
+
 module.exports = {
     isPortInRange,
     isValidCgateProjectName,
     isValidCgateUsername,
-    isValidCgatePassword
+    isValidCgatePassword,
+    normalizeOptionalSecret
 };

--- a/src/haDiscoveryPublishers.js
+++ b/src/haDiscoveryPublishers.js
@@ -1753,26 +1753,20 @@ class _HaDiscoveryPublishers {
         const labelKey = `${networkId}/${appId}/${groupId}`;
         const uniqueId = `cgateweb_${networkId}_${appId}_${groupId}_btn`;
         const entityId = entityIds.get(labelKey);
-        const discoveryTopic = `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_BUTTON}/${uniqueId}/${HA_DISCOVERY_SUFFIX}`;
-
-        const payload = {
-            name: null,
-            unique_id: uniqueId,
-            ...(entityId && entityIdFields(HA_COMPONENT_BUTTON, `${entityId}_btn`)),
-            command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_TRIGGER}`,
-            payload_press: MQTT_STATE_ON,
-            qos: 0,
-            retain: false,
-            device: buildDeviceBlock({
-                identifiers: [`cgateweb_${networkId}_${appId}_${groupId}`],
-                name: label,
-                model: HA_MODEL_TRIGGER
-            }),
-            origin: buildOriginBlock()
-        };
-
-        this._publish(discoveryTopic, JSON.stringify(payload), MQTT_RETAINED_STATE_OPTIONS);
-        this.discoveryCount++;
+        this._finishTreeEntity({
+            discoveryTopic: `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_BUTTON}/${uniqueId}/${HA_DISCOVERY_SUFFIX}`,
+            uniqueId,
+            entityId: entityId ? `${entityId}_btn` : undefined,
+            component: HA_COMPONENT_BUTTON,
+            fields: {
+                command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_TRIGGER}`,
+                payload_press: MQTT_STATE_ON,
+                retain: false
+            },
+            deviceIdentifiers: [`cgateweb_${networkId}_${appId}_${groupId}`],
+            deviceName: label,
+            model: HA_MODEL_TRIGGER
+        });
     }
 
     _publishTriggerScene(networkId, appId, groupId, label) {
@@ -1780,26 +1774,20 @@ class _HaDiscoveryPublishers {
         const labelKey = `${networkId}/${appId}/${groupId}`;
         const uniqueId = `cgateweb_${networkId}_${appId}_${groupId}_scene`;
         const entityId = entityIds.get(labelKey);
-        const discoveryTopic = `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_SCENE}/${uniqueId}/${HA_DISCOVERY_SUFFIX}`;
-
-        const payload = {
-            name: null,
-            unique_id: uniqueId,
-            ...(entityId && entityIdFields(HA_COMPONENT_SCENE, `${entityId}_scene`)),
-            command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_SWITCH}`,
-            payload_on: MQTT_STATE_ON,
-            qos: 0,
-            retain: false,
-            device: buildDeviceBlock({
-                identifiers: [`cgateweb_${networkId}_${appId}_${groupId}`],
-                name: label,
-                model: HA_MODEL_TRIGGER
-            }),
-            origin: buildOriginBlock()
-        };
-
-        this._publish(discoveryTopic, JSON.stringify(payload), MQTT_RETAINED_STATE_OPTIONS);
-        this.discoveryCount++;
+        this._finishTreeEntity({
+            discoveryTopic: `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_SCENE}/${uniqueId}/${HA_DISCOVERY_SUFFIX}`,
+            uniqueId,
+            entityId: entityId ? `${entityId}_scene` : undefined,
+            component: HA_COMPONENT_SCENE,
+            fields: {
+                command_topic: `${MQTT_TOPIC_PREFIX_WRITE}/${networkId}/${appId}/${groupId}/${MQTT_CMD_TYPE_SWITCH}`,
+                payload_on: MQTT_STATE_ON,
+                retain: false
+            },
+            deviceIdentifiers: [`cgateweb_${networkId}_${appId}_${groupId}`],
+            deviceName: label,
+            model: HA_MODEL_TRIGGER
+        });
     }
 }
 

--- a/src/mqttCommandRouter.js
+++ b/src/mqttCommandRouter.js
@@ -10,6 +10,7 @@ const {
     MQTT_TOPIC_PREFIX_READ,
     MQTT_RETAINED_STATE_OPTIONS,
     MQTT_TOPIC_SUFFIX_LEVEL,
+    MQTT_TOPIC_SUFFIX_STATE,
     MQTT_TOPIC_SUFFIX_POSITION,
     MQTT_CMD_TYPE_GETALL,
     MQTT_CMD_TYPE_GETTREE,
@@ -671,6 +672,10 @@ class MqttCommandRouter extends EventEmitter {
         }
 
         this._queueCommand(cgateCommand);
+        this._publishOptimisticLightState(command.getNetwork(), command.getApplication(), command.getGroup(), {
+            state: action,
+            levelPercent: action === MQTT_STATE_ON ? 100 : 0
+        });
     }
 
     /**
@@ -699,9 +704,17 @@ class MqttCommandRouter extends EventEmitter {
                 break;
             case MQTT_STATE_ON:
                 this._queueCommand(`${CGATE_CMD_ON} ${cbusPath}${NEWLINE}`);
+                this._publishOptimisticLightState(command.getNetwork(), command.getApplication(), command.getGroup(), {
+                    state: MQTT_STATE_ON,
+                    levelPercent: 100
+                });
                 break;
             case MQTT_STATE_OFF:
                 this._queueCommand(`${CGATE_CMD_OFF} ${cbusPath}${NEWLINE}`);
+                this._publishOptimisticLightState(command.getNetwork(), command.getApplication(), command.getGroup(), {
+                    state: MQTT_STATE_OFF,
+                    levelPercent: 0
+                });
                 break;
             default:
                 this._handleAbsoluteLevel(command, cbusPath, payload);
@@ -719,12 +732,17 @@ class MqttCommandRouter extends EventEmitter {
         const level = command.getLevel();
         const rampTime = command.getRampTime();
         
-        if (level !== null) {
+        if (typeof level === 'number') {
             let cgateCommand = `${CGATE_CMD_RAMP} ${cbusPath} ${level}`;
             if (rampTime) {
                 cgateCommand += ` ${rampTime}`;
             }
             this._queueCommand(cgateCommand + NEWLINE);
+            const levelPercent = Math.round(level / CGATE_LEVEL_MAX * 100);
+            this._publishOptimisticLightState(command.getNetwork(), command.getApplication(), command.getGroup(), {
+                state: level > 0 ? MQTT_STATE_ON : MQTT_STATE_OFF,
+                levelPercent
+            });
         } else {
             this.logger.warn(`Invalid payload for ramp command: ${payload}`);
         }
@@ -755,6 +773,11 @@ class MqttCommandRouter extends EventEmitter {
             const newLevel = Math.max(CGATE_LEVEL_MIN, Math.min(limit, currentLevel + step));
             this.logger.debug(`${actionName}: ${levelAddress} ${currentLevel} -> ${newLevel}`);
             this._queueCommand(`${CGATE_CMD_RAMP} ${cbusPath} ${newLevel}${NEWLINE}`);
+            const [network, application, group] = levelAddress.split('/');
+            this._publishOptimisticLightState(network, application, group, {
+                state: newLevel > 0 ? MQTT_STATE_ON : MQTT_STATE_OFF,
+                levelPercent: Math.round(newLevel / CGATE_LEVEL_MAX * 100)
+            });
         }, timeoutMs);
 
         // Query current level first; the response drives the callback above.
@@ -1180,6 +1203,32 @@ class MqttCommandRouter extends EventEmitter {
         // Keep the learned state coherent until the thermostat's echo broadcast.
         this.airconControlRegistry.noteSetpointWrite(network, unit, modeRaw, level);
         this.logger.info(`Native HVAC setpoint: ${network}/${unit} -> ${clamped}°C (ward ${state.ward}, zones ${state.zones})`);
+    }
+
+    /**
+     * Publish expected lighting state/level immediately after a write so Home
+     * Assistant's light card updates without waiting for the C-Gate event port
+     * (issue #52: dim from HA succeeded on the bus while the entity stayed off).
+     * The real event confirms the same topics shortly after.
+     * @param {string} network
+     * @param {string} application
+     * @param {string} group
+     * @param {{ state?: string, levelPercent?: number }} [fields]
+     * @private
+     */
+    _publishOptimisticLightState(network, application, group, fields = {}) {
+        if (!this.mqttClient || typeof this.mqttClient.publish !== 'function') return;
+        if (!network || !application || !group) return;
+        const state = fields.state;
+        const levelPercent = fields.levelPercent;
+        const base = `${MQTT_TOPIC_PREFIX_READ}/${network}/${application}/${group}`;
+        const opts = this.settings.retainreads ? MQTT_RETAINED_STATE_OPTIONS : { qos: 0 };
+        if (state !== undefined && state !== null) {
+            this.mqttClient.publish(`${base}/${MQTT_TOPIC_SUFFIX_STATE}`, String(state), opts);
+        }
+        if (levelPercent !== undefined && levelPercent !== null) {
+            this.mqttClient.publish(`${base}/${MQTT_TOPIC_SUFFIX_LEVEL}`, String(levelPercent), opts);
+        }
     }
 
     /**

--- a/src/mqttManager.js
+++ b/src/mqttManager.js
@@ -12,6 +12,7 @@ const {
     MQTT_ERROR_AUTH
 } = require('./constants');
 const { resolveSetting } = require('./config/schema');
+const { normalizeOptionalSecret } = require('./config/validationRules');
 
 /**
  * Manages MQTT broker connection and message handling for the C-Bus bridge.
@@ -249,11 +250,12 @@ class MqttManager extends EventEmitter {
             }
         };
 
-        if (this.settings.mqttusername && typeof this.settings.mqttusername === 'string') {
-            options.username = this.settings.mqttusername;
-            
-            if (this.settings.mqttpassword && typeof this.settings.mqttpassword === 'string') {
-                options.password = this.settings.mqttpassword;
+        const username = normalizeOptionalSecret(this.settings.mqttusername);
+        if (username) {
+            options.username = username;
+            const password = normalizeOptionalSecret(this.settings.mqttpassword);
+            if (password) {
+                options.password = password;
             }
         }
 

--- a/src/web/labelRoutes.js
+++ b/src/web/labelRoutes.js
@@ -253,7 +253,8 @@ class LabelRoutes {
         try {
             result = await this._parser.parse(fileBuffer, filename);
         } catch (err) {
-            return sendJSON(res, 400, { error: err.message });
+            this.logger.error('Label import failed', { error: err.message });
+            return sendJSON(res, 400, { error: 'Invalid or unsupported project file' });
         }
 
         try {

--- a/tests/cbusProjectParser.test.js
+++ b/tests/cbusProjectParser.test.js
@@ -224,6 +224,18 @@ describe('CbusProjectParser', () => {
                 .rejects.toThrow(/too many elements/i);
         });
 
+        it('rejects when xml2js throws synchronously instead of hanging the promise', async () => {
+            await jest.isolateModulesAsync(async () => {
+                jest.doMock('xml2js', () => ({
+                    parseString: () => { throw new Error('sync boom'); }
+                }));
+                const IsolatedParser = require('../src/cbusProjectParser');
+                const isolated = new IsolatedParser();
+                await expect(isolated.parseXML('<?xml version="1.0"?><Network/>'))
+                    .rejects.toThrow(/XML parse error: sync boom/);
+            });
+        });
+
         it('should handle Label attribute as alternative to TagName', async () => {
             const xml = `<?xml version="1.0"?>
                 <Network Address="254">

--- a/tests/cgateConnectionPool.test.js
+++ b/tests/cgateConnectionPool.test.js
@@ -746,6 +746,24 @@ describe('CgateConnectionPool', () => {
             expect(pool.healthyConnections.has(conn)).toBe(false);
         });
 
+        it('_checkConnectionHealth pings when inactive longer than twice keep-alive', async () => {
+            await pool.start();
+            const [conn] = pool.connections;
+            conn.lastActivity = Date.now() - (pool.keepAliveInterval * 2 + 1);
+            pool._checkConnectionHealth(conn);
+            expect(conn.send).toHaveBeenCalledWith(expect.stringContaining('Health check ping'));
+            expect(pool.healthyConnections.has(conn)).toBe(true);
+        });
+
+        it('_checkConnectionHealth removes the connection when the health ping throws', async () => {
+            await pool.start();
+            const [conn] = pool.connections;
+            conn.lastActivity = Date.now() - (pool.keepAliveInterval * 2 + 1);
+            conn.send = jest.fn().mockImplementation(() => { throw new Error('write failed'); });
+            pool._checkConnectionHealth(conn);
+            expect(pool.healthyConnections.has(conn)).toBe(false);
+        });
+
         it('fires health check on interval', async () => {
             await pool.start();
             const spy = jest.spyOn(pool, '_performHealthCheck');

--- a/tests/config/configLoader.test.js
+++ b/tests/config/configLoader.test.js
@@ -95,6 +95,17 @@ describe('ConfigLoader', () => {
             expect(config._environment.type).toBe('addon');
         });
 
+        test('trims MQTT credentials and treats whitespace-only passwords as unset', () => {
+            const options = { ...mockAddonOptions, mqtt_username: '  user  ', mqtt_password: '   ' };
+            fs.existsSync.mockReturnValue(true);
+            fs.readFileSync.mockReturnValue(JSON.stringify(options));
+
+            const config = configLoader.load();
+
+            expect(config.mqttusername).toBe('user');
+            expect(config.mqttpassword).toBeNull();
+        });
+
         test('should handle minimal addon configuration', () => {
             const minimalOptions = {
                 cgate_host: '127.0.0.1',

--- a/tests/haDiscovery.test.js
+++ b/tests/haDiscovery.test.js
@@ -2204,6 +2204,35 @@ describe('HaDiscovery', () => {
             expect(haDiscovery._publishedTopics.has('testhomeassistant/light/cgateweb_254_56_10/config')).toBe(false);
         });
 
+        it('clears trigger button and scene companions when the group is excluded on a second run', () => {
+            mockSettings.ha_discovery_trigger_app_id = '203';
+            mockSettings.ha_discovery_cover_app_id = null;
+            mockSettings.ha_discovery_scene_enabled = true;
+            publishTree(haDiscovery);
+
+            const btnTopic = 'testhomeassistant/button/cgateweb_254_203_15_btn/config';
+            const sceneTopic = 'testhomeassistant/scene/cgateweb_254_203_15_scene/config';
+            const eventTopic = 'testhomeassistant/event/cgateweb_254_203_15/config';
+            expect(haDiscovery._publishedTopics.has(btnTopic)).toBe(true);
+            expect(haDiscovery._publishedTopics.has(sceneTopic)).toBe(true);
+            expect(haDiscovery._publishedTopics.has(eventTopic)).toBe(true);
+
+            haDiscovery.updateLabels({
+                labels: new Map(),
+                typeOverrides: new Map(),
+                entityIds: new Map(),
+                exclude: new Set(['254/203/15'])
+            });
+            mockPublishFn.mockClear();
+            publishTree(haDiscovery);
+
+            for (const topic of [btnTopic, sceneTopic, eventTopic]) {
+                const cleanup = mockPublishFn.mock.calls.find(c => c[0] === topic && c[1] === '');
+                expect(cleanup).toBeDefined();
+                expect(haDiscovery._publishedTopics.has(topic)).toBe(false);
+            }
+        });
+
         it('should clear the old light topic when a device changes type from light to cover across runs', () => {
             // First run: device 254/56/10 published as a light
             publishTree(haDiscovery);

--- a/tests/mqttCommandRouter.test.js
+++ b/tests/mqttCommandRouter.test.js
@@ -830,6 +830,21 @@ describe('MqttCommandRouter', () => {
 
                 expect(queueSpy).toHaveBeenCalledWith('TERMINATERAMP //TestProject/254/56/53\n', { priority: 'critical' });
             });
+
+            it('does not echo state when STOP is routed as a cover stop', () => {
+                const publish = jest.fn();
+                router.mqttClient = { publish };
+                router.routeMessage('cbus/write/254/56/53/switch', 'STOP');
+                expect(publish).not.toHaveBeenCalled();
+            });
+
+            it('echoes ON/OFF to read topics so HA updates before the C-Gate event (issue #52)', () => {
+                const publish = jest.fn();
+                router.mqttClient = { publish };
+                router.routeMessage('cbus/write/254/56/1/switch', 'ON');
+                expect(publish).toHaveBeenCalledWith('cbus/read/254/56/1/state', 'ON', { qos: 0 });
+                expect(publish).toHaveBeenCalledWith('cbus/read/254/56/1/level', '100', { qos: 0 });
+            });
         });
 
         describe('Ramp Commands', () => {
@@ -837,6 +852,14 @@ describe('MqttCommandRouter', () => {
                 router.routeMessage('cbus/write/254/56/1/ramp', '75');
                 
                 expect(queueSpy).toHaveBeenCalledWith('RAMP //TestProject/254/56/1 191\n');
+            });
+
+            it('echoes dimmer level and ON to read topics before the C-Gate event (issue #52)', () => {
+                const publish = jest.fn();
+                router.mqttClient = { publish };
+                router.routeMessage('cbus/write/254/56/1/ramp', '75');
+                expect(publish).toHaveBeenCalledWith('cbus/read/254/56/1/state', 'ON', { qos: 0 });
+                expect(publish).toHaveBeenCalledWith('cbus/read/254/56/1/level', '75', { qos: 0 });
             });
 
             it('should handle ramp with time specification', () => {

--- a/tests/mqttManager.test.js
+++ b/tests/mqttManager.test.js
@@ -60,6 +60,30 @@ describe('MqttManager', () => {
             expect(mqttManager.client).toBe(mockClient);
         });
 
+        it('trims MQTT credentials and treats whitespace-only passwords as unset', () => {
+            const padded = new MqttManager({
+                mqtt: 'localhost:1883',
+                mqttusername: '  testuser  ',
+                mqttpassword: '  testpass  '
+            });
+            padded.connect();
+            expect(mqtt.connect).toHaveBeenCalledWith('mqtt://localhost:1883', expect.objectContaining({
+                username: 'testuser',
+                password: 'testpass'
+            }));
+
+            mqtt.connect.mockClear();
+            const blank = new MqttManager({
+                mqtt: 'localhost:1883',
+                mqttusername: 'testuser',
+                mqttpassword: '   '
+            });
+            blank.connect();
+            const opts = mqtt.connect.mock.calls[0][1];
+            expect(opts.username).toBe('testuser');
+            expect(opts.password).toBeUndefined();
+        });
+
         it('should handle settings without authentication', () => {
             const noAuthSettings = { mqtt: 'localhost:1883' };
             const noAuthManager = new MqttManager(noAuthSettings);

--- a/tests/webServer.test.js
+++ b/tests/webServer.test.js
@@ -1389,7 +1389,7 @@ describe('WebServer', () => {
                 req.end();
             });
             expect(res.status).toBe(400);
-            expect(res.body.error).toContain('bad file');
+            expect(res.body.error).toBe('Invalid or unsupported project file');
         });
 
         it('returns 400 when no body is sent', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Six leftover items from the last survey, each as its own commit. No version or changelog bump. Please rebase-merge (not squash) so they stay separate on master.

Issue #52’s original report was a TLS event-port config problem; the lighting echo commit does not replace that diagnosis. It publishes expected state/level immediately after HA dim/switch so the card does not stay off until the event port confirms.

## Changes

1. Reject sync xml2js throws so label import cannot hang.
2. Stable 400 on import; skip unsafe zip names before sniff inflate.
3. Tests for pool health pings on inactive connections.
4. Trim MQTT and C-Gate credentials; blank after trim is unset.
5. Track trigger button/scene discovery so stale cleanup retracts companions.
6. Echo lighting state after HA dim and switch commands.

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification

## Checklist

- [ ] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [ ] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

