### PR TITLE
Harden reload validation, event-parse logs, status API, and tunables

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,11 +55,15 @@ const envOverrides = {
     CGATE_PROJECT: 'cbusname',
 };
 
-for (const [envKey, settingKey] of Object.entries(envOverrides)) {
-    if (process.env[envKey] !== undefined) {
-        settings[settingKey] = process.env[envKey];
+function applyEnvOverrides(target) {
+    for (const [envKey, settingKey] of Object.entries(envOverrides)) {
+        if (process.env[envKey] !== undefined) {
+            target[settingKey] = process.env[envKey];
+        }
     }
 }
+
+applyEnvOverrides(settings);
 
 
 // Application startup
@@ -93,6 +97,10 @@ async function main() {
     process.on('SIGINT', () => shutdown('SIGINT'));
     process.on('SIGUSR1', () => {
         console.log('[INFO] Received SIGUSR1, reloading configuration...');
+        // load(true) overwrites ConfigLoader's cache before we know the file is
+        // valid. Keep the startup snapshot so a failed reload cannot leave a
+        // broken config as "current" for the next getConfig() caller.
+        const previousCache = configLoader._cachedConfig;
         try {
             // forceReload, or this reloads nothing: ConfigLoader.load() returns
             // its cached config from startup unless told otherwise, so SIGUSR1
@@ -101,9 +109,14 @@ async function main() {
             // one `systemctl reload` away from anyone editing settings.js.
             const reloaded = configLoader.load(true);
             const newSettings = { ...defaultSettings, ...reloaded };
+            applyEnvOverrides(newSettings);
+            // Same gate as boot: a settings.js that would abort startup must
+            // not be applied mid-run (and must not log success).
+            configLoader.validate(newSettings);
             bridge.reloadSettings(newSettings);
             console.log('[INFO] Configuration reloaded successfully');
         } catch (error) {
+            configLoader._cachedConfig = previousCache;
             console.error(`[ERROR] Failed to reload configuration: ${error.message}`);
         }
     });

--- a/src/cgateWebBridge.js
+++ b/src/cgateWebBridge.js
@@ -546,6 +546,9 @@ class CgateWebBridge {
 
         return discoverIngressEntry({
             token: supervisorToken,
+            timeoutMs: resolveSetting(this.settings, 'ingressDiscoveryTimeoutMs'),
+            attempts: resolveSetting(this.settings, 'ingressDiscoveryAttempts'),
+            initialRetryDelayMs: resolveSetting(this.settings, 'ingressDiscoveryInitialRetryDelayMs'),
             maxRetryDelayMs: resolveSetting(this.settings, 'ingressDiscoveryMaxBackoffMs')
         })
             .then((ingressEntry) => {

--- a/src/cgateWebBridge.js
+++ b/src/cgateWebBridge.js
@@ -787,7 +787,7 @@ class CgateWebBridge {
             return;
         }
         if (measurementState === LINE_UNPARSED) {
-            this.logger.debug(`Unparsed measurement line (captured, not a standard event): ${line}`);
+            this.logger.debug(`Unparsed measurement line (captured, not a standard event): ${redactCgateLine(line)}`);
             return;
         }
         // Reached when the feature is off, or on but the line was a shape the
@@ -815,10 +815,10 @@ class CgateWebBridge {
                     }
                 }
             } else {
-                this.warn(`Could not parse event line: ${line}`);
+                this.warn(`Could not parse event line: ${redactCgateLine(line)}`);
             }
         } catch (e) {
-            this.error(`Error processing event data line: ${e.message}`, { line });
+            this.error(`Error processing event data line: ${e.message}`, { line: redactCgateLine(line) });
         }
     }
 

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -696,6 +696,15 @@ const SETTINGS_SCHEMA = {
         description: 'Allow Home Assistant to CONTROL native Air Conditioning thermostats (set mode/setpoint) via AIRCON commands.',
         reason: 'Opt-in. Off by default - it writes to live heating/cooling. Requires cbus_aircon_app_id to be set.'
     },
+    airconSetpointDebounceMs: {
+        key: 'airconSetpointDebounceMs',
+        type: 'number',
+        default: 3000,
+        unit: 'ms',
+        exposure: 'standalone',
+        description: 'Wait after the last native-aircon setpoint change before sending a single AIRCON write (spec timeout on adjustment).',
+        reason: TUNING_ONLY_REASON
+    },
 
     // --- Security (application 208) -----------------------------------------
     cbus_security_app_id: {
@@ -953,6 +962,33 @@ const SETTINGS_SCHEMA = {
         unit: 'ms',
         exposure: 'standalone',
         description: 'Ceiling for the Supervisor ingress-path discovery retry backoff after add-on start.',
+        reason: TUNING_ONLY_REASON
+    },
+    ingressDiscoveryTimeoutMs: {
+        key: 'ingressDiscoveryTimeoutMs',
+        type: 'number',
+        default: 5000,
+        unit: 'ms',
+        exposure: 'standalone',
+        description: 'Per-request timeout for Supervisor ingress-path discovery after add-on start.',
+        reason: TUNING_ONLY_REASON
+    },
+    ingressDiscoveryAttempts: {
+        key: 'ingressDiscoveryAttempts',
+        type: 'number',
+        default: 4,
+        unit: 'none',
+        exposure: 'standalone',
+        description: 'How many Supervisor ingress-path lookup attempts to make after add-on start.',
+        reason: TUNING_ONLY_REASON
+    },
+    ingressDiscoveryInitialRetryDelayMs: {
+        key: 'ingressDiscoveryInitialRetryDelayMs',
+        type: 'number',
+        default: 1000,
+        unit: 'ms',
+        exposure: 'standalone',
+        description: 'Initial backoff between Supervisor ingress-path discovery retries.',
         reason: TUNING_ONLY_REASON
     },
     web_auth_failure_rate_limit_per_minute: {

--- a/src/ingressDiscovery.js
+++ b/src/ingressDiscovery.js
@@ -49,23 +49,32 @@ function _fetchAddonInfo({ token, httpModule = httpDefault, timeoutMs = 5000 } =
  * @param {object} [options]
  * @param {string} [options.token] - the SUPERVISOR_TOKEN injected into the add-on container
  * @param {typeof httpDefault} [options.httpModule] - http implementation override (testing)
- * @param {number} [options.timeoutMs=5000] - per-request timeout
- * @param {number} [options.attempts=4] - total attempts before giving up
- * @param {number} [options.initialRetryDelayMs=1000] - base delay for the retry backoff
+ * @param {number} [options.timeoutMs] - per-request timeout (schema: ingressDiscoveryTimeoutMs)
+ * @param {number} [options.attempts] - total attempts before giving up (schema: ingressDiscoveryAttempts)
+ * @param {number} [options.initialRetryDelayMs] - base delay for the retry backoff (schema: ingressDiscoveryInitialRetryDelayMs)
  * @param {number} [options.maxRetryDelayMs] - ceiling for the retry backoff (schema: ingressDiscoveryMaxBackoffMs)
  * @param {Function} [options.sleep] - sleep implementation override (testing)
  * @returns {Promise<string|null>} the ingress entry path, or null when it could not be determined
  */
-async function discoverIngressEntry({ token, httpModule, timeoutMs, attempts = 4, initialRetryDelayMs = 1000, maxRetryDelayMs, sleep } = {}) {
+async function discoverIngressEntry({ token, httpModule, timeoutMs, attempts, initialRetryDelayMs, maxRetryDelayMs, sleep } = {}) {
     if (!token) return null;
     const doSleep = sleep || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+    const resolvedTimeoutMs = timeoutMs !== undefined
+        ? timeoutMs
+        : resolveSetting({}, 'ingressDiscoveryTimeoutMs');
+    const resolvedAttempts = attempts !== undefined
+        ? attempts
+        : resolveSetting({}, 'ingressDiscoveryAttempts');
+    const resolvedInitialRetryDelayMs = initialRetryDelayMs !== undefined
+        ? initialRetryDelayMs
+        : resolveSetting({}, 'ingressDiscoveryInitialRetryDelayMs');
     const maxMs = maxRetryDelayMs !== undefined
         ? maxRetryDelayMs
         : resolveSetting({}, 'ingressDiscoveryMaxBackoffMs');
 
-    for (let attempt = 1; attempt <= attempts; attempt++) {
+    for (let attempt = 1; attempt <= resolvedAttempts; attempt++) {
         try {
-            const info = await _fetchAddonInfo({ token, httpModule, timeoutMs });
+            const info = await _fetchAddonInfo({ token, httpModule, timeoutMs: resolvedTimeoutMs });
             const entry = info && info.data && typeof info.data.ingress_entry === 'string'
                 ? info.data.ingress_entry.trim()
                 : '';
@@ -74,8 +83,8 @@ async function discoverIngressEntry({ token, httpModule, timeoutMs, attempts = 4
             }
             throw new Error('Supervisor response did not include an ingress entry path');
         } catch {
-            if (attempt >= attempts) break;
-            await doSleep(backoffDelay(attempt - 1, { initialMs: initialRetryDelayMs, maxMs }));
+            if (attempt >= resolvedAttempts) break;
+            await doSleep(backoffDelay(attempt - 1, { initialMs: resolvedInitialRetryDelayMs, maxMs }));
         }
     }
 

--- a/src/measurementEventHandler.js
+++ b/src/measurementEventHandler.js
@@ -3,6 +3,7 @@
 
 const measurementDecoder = require('./applicationDecoders/measurementDecoder');
 const { LINE_UNPARSED } = require('./applicationDecoders/appEventLine');
+const { redactCgateLine } = require('./utils');
 
 /**
  * Handles C-Bus Measurement Application (app 228 / $E4) event lines, which
@@ -78,7 +79,7 @@ class MeasurementEventHandler {
         // Don't consume it — the bridge logs it as unparsed and keeps it out of
         // the standard parser.
         if (this.logger.isLevelEnabled && this.logger.isLevelEnabled('debug')) {
-            this.logger.debug(`Measurement line not natively decoded: ${line}`);
+            this.logger.debug(`Measurement line not natively decoded: ${redactCgateLine(line)}`);
         }
         return LINE_UNPARSED;
     }

--- a/src/mqttCommandRouter.js
+++ b/src/mqttCommandRouter.js
@@ -94,9 +94,6 @@ const SECURITY_ARM_MODE_BY_PAYLOAD = {
     ARM_HOME: 'day',
     ARM_VACATION: 'vacation'
 };
-// Debounce window for native-aircon setpoint writes (spec §25.12.11: wait a
-// few seconds after the user finishes adjusting, then send a single message).
-const AIRCON_SETPOINT_DEBOUNCE_MS = 3000;
 
 class MqttCommandRouter extends EventEmitter {
     /**
@@ -1154,13 +1151,14 @@ class MqttCommandRouter extends EventEmitter {
         const key = `${network}/${unit}`;
         const pending = this._airconSetpointTimers.get(key);
         if (pending) clearTimeout(pending.handle);
+        const delayMs = resolveSetting(this.settings, 'airconSetpointDebounceMs');
         const handle = setTimeout(() => {
             this._airconSetpointTimers.delete(key);
             this._sendAirconSetpoint(network, application, unit, clamped);
-        }, AIRCON_SETPOINT_DEBOUNCE_MS);
+        }, delayMs);
         if (typeof handle.unref === 'function') handle.unref();
         this._airconSetpointTimers.set(key, { handle });
-        this.logger.debug(`Native HVAC setpoint: ${network}/${unit} -> ${clamped}°C queued (debounced ${AIRCON_SETPOINT_DEBOUNCE_MS}ms)`);
+        this.logger.debug(`Native HVAC setpoint: ${network}/${unit} -> ${clamped}°C queued (debounced ${delayMs}ms)`);
     }
 
     /**

--- a/src/web/statusRoutes.js
+++ b/src/web/statusRoutes.js
@@ -51,8 +51,7 @@ class StatusRoutes {
         sendJSON(res, 200, {
             ...status,
             labels: {
-                count: Object.keys(labels).length,
-                filePath: this.labelLoader.filePath
+                count: Object.keys(labels).length
             }
         });
     }

--- a/tests/airconWriteControl.test.js
+++ b/tests/airconWriteControl.test.js
@@ -53,6 +53,16 @@ describe('native HVAC write control (AIRCON commands)', () => {
         expect(queued[0].trim()).toBe('AIRCON SET_ZONE_HVAC_MODE //THEGAFF/254/172 1 0 1 0 0 0 1 3 6400 0');
     });
 
+    it('honours airconSetpointDebounceMs from settings', () => {
+        const { router, queued } = makeRouter();
+        router.settings.airconSetpointDebounceMs = 500;
+        router.routeMessage('cbus/write/254/172/202/setpoint', '25');
+        jest.advanceTimersByTime(499);
+        expect(queued).toHaveLength(0);
+        jest.advanceTimersByTime(1);
+        expect(queued).toHaveLength(1);
+    });
+
     it('shutdown() clears pending debounced setpoint timers so nothing fires afterwards', () => {
         const { router, queued } = makeRouter();
         router.routeMessage('cbus/write/254/172/202/setpoint', '25');

--- a/tests/bridgeIngressDiscovery.test.js
+++ b/tests/bridgeIngressDiscovery.test.js
@@ -29,6 +29,7 @@ describe('CgateWebBridge._discoverIngressBasePath (GitHub #33)', () => {
         fakeBridge = {
             webServer,
             logger: { info: jest.fn(), warn: jest.fn(), debug: jest.fn(), error: jest.fn() },
+            settings: {},
             _discoverIngressBasePath: CgateWebBridge.prototype._discoverIngressBasePath
         };
     });
@@ -47,7 +48,13 @@ describe('CgateWebBridge._discoverIngressBasePath (GitHub #33)', () => {
 
         await fakeBridge._discoverIngressBasePath();
 
-        expect(discoverIngressEntry).toHaveBeenCalledWith(expect.objectContaining({ token: 'tok' }));
+        expect(discoverIngressEntry).toHaveBeenCalledWith(expect.objectContaining({
+            token: 'tok',
+            timeoutMs: 5000,
+            attempts: 4,
+            initialRetryDelayMs: 1000,
+            maxRetryDelayMs: 8000
+        }));
         expect(webServer.basePath).toBe('/api/hassio_ingress/discovered123');
     });
 

--- a/tests/cgateWebBridge.test.js
+++ b/tests/cgateWebBridge.test.js
@@ -772,6 +772,54 @@ describe('CgateWebBridge', () => {
                 publishEventSpy.mockRestore();
             });
 
+            it('redacts keypad echoes in failed event-parse warnings', () => {
+                const warnSpy = jest.spyOn(bridge, 'warn');
+                const line = 'not-an-event security emulate_keypad //P/254/208 7';
+
+                bridge._processEventLine(line);
+
+                expect(warnSpy).toHaveBeenCalledTimes(1);
+                const message = warnSpy.mock.calls[0][0];
+                expect(message).toContain('Could not parse event line:');
+                expect(message).toContain('***');
+                expect(message).not.toMatch(/emulate_keypad \S+\s+7\b/i);
+                warnSpy.mockRestore();
+            });
+
+            it('redacts keypad echoes in unparsed measurement debug logs', () => {
+                const debugSpy = jest.spyOn(bridge.logger, 'debug');
+                const line = 'measurement not_a_real_verb //P/254/228/1/0 security emulate_keypad //P/254/208 7';
+                bridge.settings.cbus_measurement_app_id = '228';
+
+                bridge._processEventLine(line);
+
+                const messages = debugSpy.mock.calls.map((c) => String(c[0]));
+                expect(messages.some((m) => m.includes('Unparsed measurement line'))).toBe(true);
+                expect(messages.join('\n')).toContain('***');
+                expect(messages.join('\n')).not.toMatch(/emulate_keypad \S+\s+7\b/i);
+                debugSpy.mockRestore();
+            });
+
+            it('redacts keypad echoes when processing an event line throws', () => {
+                const errorSpy = jest.spyOn(bridge, 'error');
+                const line = 'lighting on 254/56/1 security emulate_keypad //P/254/208 7';
+                jest.spyOn(bridge.deviceStateManager, 'updateLevelFromEvent').mockImplementation(() => {
+                    throw new Error('boom');
+                });
+
+                bridge._processEventLine(line);
+
+                expect(errorSpy).toHaveBeenCalledWith(
+                    'Error processing event data line: boom',
+                    expect.objectContaining({
+                        line: expect.stringContaining('***')
+                    })
+                );
+                const logged = errorSpy.mock.calls[0][1].line;
+                expect(logged).not.toMatch(/emulate_keypad \S+\s+7\b/i);
+                errorSpy.mockRestore();
+            });
+
             it('should ignore clock date events without publishing', () => {
                 const publishEventSpy = jest.spyOn(bridge.eventPublisher, 'publishEvent');
                 

--- a/tests/defaultSettings.test.js
+++ b/tests/defaultSettings.test.js
@@ -11,14 +11,14 @@ describe('defaultSettings — frozen baseline', () => {
         expect(defaultSettings).toStrictEqual(defaultSettingsSnapshot);
     });
 
-    it('exports the same 127 keys as the baseline', () => {
+    it('exports the same 131 keys as the baseline', () => {
         expect(Object.keys(defaultSettings).sort())
             .toEqual(Object.keys(defaultSettingsSnapshot).sort());
         // Bumping this count is only ever legitimate alongside a genuinely NEW
         // setting added to the fixture; a changed value for an existing key is
         // the thing this baseline exists to catch, and must never be "fixed"
         // in the fixture.
-        expect(Object.keys(defaultSettings)).toHaveLength(127);
+        expect(Object.keys(defaultSettings)).toHaveLength(131);
     });
 
     it('returns a fresh object so consumers cannot mutate the schema defaults', () => {

--- a/tests/eventPublisher.test.js
+++ b/tests/eventPublisher.test.js
@@ -317,6 +317,21 @@ describe('EventPublisher', () => {
                 mockMqttOptions
             );
         });
+
+        it('cancels an interpolated cover ramp when a real C-Gate event arrives', () => {
+            const coverRampTracker = { cancelRamp: jest.fn() };
+            const publisher = new EventPublisher({
+                settings: mockSettings,
+                publishFn: mockPublishFn,
+                mqttOptions: mockMqttOptions,
+                logger: mockLogger,
+                coverRampTracker
+            });
+
+            publisher.publishEvent(new CBusEvent('lighting ramp 254/203/5 128'), '(Evt)');
+
+            expect(coverRampTracker.cancelRamp).toHaveBeenCalledWith('254/203/5');
+        });
     });
 
     describe('Type override cover publishing', () => {
@@ -891,6 +906,15 @@ describe('EventPublisher', () => {
         });
 
         it.each([
+            [true, 'ON'],
+            [false, 'OFF']
+        ])('should publish security_panel %s as state=%s', (active, state) => {
+            publish('panel/mains', { kind: 'security_panel', active }, '254', '208');
+            expect(mockPublishFn).toHaveBeenCalledTimes(1);
+            expectCall('cbus/read/254/208/panel/mains/state', state);
+        });
+
+        it.each([
             // A panel can bypass a zone before the initial status report lands.
             // The isolation is still worth showing, but nothing is known about
             // the zone's state, so the state topic must stay untouched.
@@ -1131,6 +1155,29 @@ describe('EventPublisher', () => {
                 expect.anything(),
                 expect.anything()
             );
+        });
+    });
+
+    describe('shutdown', () => {
+        it('clears a pending coalesce flush so shutdown does not publish later', () => {
+            jest.useFakeTimers();
+            const publisher = new EventPublisher({
+                settings: { ...mockSettings, eventPublishCoalesce: true },
+                publishFn: mockPublishFn,
+                mqttOptions: mockMqttOptions,
+                logger: mockLogger
+            });
+
+            publisher.publishEvent(new CBusEvent('lighting on 254/56/1'));
+            expect(publisher.getStats().coalesceBufferSize).toBeGreaterThan(0);
+            expect(publisher.getStats().coalesceEnabled).toBe(true);
+
+            publisher.shutdown();
+
+            expect(publisher.getStats().coalesceBufferSize).toBe(0);
+            jest.runOnlyPendingTimers();
+            expect(mockPublishFn).not.toHaveBeenCalled();
+            jest.useRealTimers();
         });
     });
 });

--- a/tests/fixtures/defaultSettings.snapshot.json
+++ b/tests/fixtures/defaultSettings.snapshot.json
@@ -1,4 +1,5 @@
 {
+  "airconSetpointDebounceMs": 3000,
   "autoDiscoverNetworks": true,
   "cbusRawEventLogApps": [],
   "cbus_aircon_app_id": null,
@@ -77,7 +78,10 @@
   "ha_discovery_type_from_unit": false,
   "ha_hvac_temperature_unit": "C",
   "healthCheckInterval": 30000,
+  "ingressDiscoveryAttempts": 4,
+  "ingressDiscoveryInitialRetryDelayMs": 1000,
   "ingressDiscoveryMaxBackoffMs": 8000,
+  "ingressDiscoveryTimeoutMs": 5000,
   "initDebounceMs": 10000,
   "keepAliveInterval": 60000,
   "labelReloadRetryMs": 2000,

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -335,6 +335,66 @@ describe('index.js', () => {
         expect(errorSpy).toHaveBeenCalledWith('[ERROR] Failed to reload configuration: bad config');
     });
 
+    it('SIGUSR1 validates the newly read settings before applying them', async () => {
+        const processOnSpy = jest.spyOn(process, 'on');
+        const { indexModule, mockConfigLoaderInstance, bridgeInstance } = loadIndexWithMocks();
+
+        await indexModule.main();
+        mockConfigLoaderInstance.validate.mockClear();
+        mockConfigLoaderInstance.load.mockReturnValue({ log_level: 'debug', cbusip: '10.0.0.10', mqtt: 'broker:1883' });
+
+        const sigusr1Handler = processOnSpy.mock.calls.find(c => c[0] === 'SIGUSR1')[1];
+        sigusr1Handler();
+
+        expect(mockConfigLoaderInstance.validate).toHaveBeenCalledWith(
+            expect.objectContaining({ log_level: 'debug' })
+        );
+        expect(bridgeInstance.reloadSettings).toHaveBeenCalled();
+        expect(logSpy).toHaveBeenCalledWith('[INFO] Configuration reloaded successfully');
+    });
+
+    it('SIGUSR1 does not apply or announce success when validation fails', async () => {
+        const processOnSpy = jest.spyOn(process, 'on');
+        const { indexModule, mockConfigLoaderInstance, bridgeInstance } = loadIndexWithMocks();
+
+        await indexModule.main();
+        mockConfigLoaderInstance.validate.mockImplementation(() => {
+            throw new Error('Configuration validation failed: C-Gate IP address (cbusip) is required');
+        });
+        mockConfigLoaderInstance.load.mockReturnValue({ log_level: 'debug' });
+
+        const sigusr1Handler = processOnSpy.mock.calls.find(c => c[0] === 'SIGUSR1')[1];
+        sigusr1Handler();
+
+        expect(bridgeInstance.reloadSettings).not.toHaveBeenCalled();
+        expect(logSpy).not.toHaveBeenCalledWith('[INFO] Configuration reloaded successfully');
+        expect(errorSpy).toHaveBeenCalledWith(
+            '[ERROR] Failed to reload configuration: Configuration validation failed: C-Gate IP address (cbusip) is required'
+        );
+    });
+
+    it('SIGUSR1 restores the previous config cache when validation fails after load', async () => {
+        const processOnSpy = jest.spyOn(process, 'on');
+        const { indexModule, mockConfigLoaderInstance } = loadIndexWithMocks();
+
+        await indexModule.main();
+        const previous = { cbusip: '10.0.0.10', mqtt: 'broker:1883' };
+        mockConfigLoaderInstance._cachedConfig = previous;
+        mockConfigLoaderInstance.load.mockImplementation(() => {
+            const next = { cbusip: 'your-cgate-ip' };
+            mockConfigLoaderInstance._cachedConfig = next;
+            return next;
+        });
+        mockConfigLoaderInstance.validate.mockImplementation(() => {
+            throw new Error('Configuration validation failed: C-Gate IP address (cbusip) is required');
+        });
+
+        const sigusr1Handler = processOnSpy.mock.calls.find(c => c[0] === 'SIGUSR1')[1];
+        sigusr1Handler();
+
+        expect(mockConfigLoaderInstance._cachedConfig).toBe(previous);
+    });
+
     it('uncaughtException handler stops bridge and exits', async () => {
         const processOnSpy = jest.spyOn(process, 'on');
         const { indexModule, bridgeInstance } = loadIndexWithMocks();

--- a/tests/rateLimiter.test.js
+++ b/tests/rateLimiter.test.js
@@ -1,0 +1,29 @@
+const RateLimiter = require('../src/web/rateLimiter');
+
+describe('RateLimiter', () => {
+    it('defaults the window, request cap, and tracked-source cap', () => {
+        const limiter = new RateLimiter();
+        expect(limiter.windowMs).toBe(60000);
+        expect(limiter.maxRequests).toBe(120);
+        expect(limiter.maxTrackedSources).toBe(5000);
+    });
+
+    it('keys missing sockets as unknown rather than throwing', () => {
+        const limiter = new RateLimiter({ windowMs: 60000, maxRequests: 2 });
+        expect(limiter.isLimited({})).toBe(false);
+        expect(limiter.isLimited({ socket: {} })).toBe(false);
+        expect(limiter.isLimited({ socket: { remoteAddress: undefined } })).toBe(true);
+        expect(limiter._requestLog.has('unknown')).toBe(true);
+    });
+
+    it('does not evict the caller when it is the oldest tracked source', () => {
+        // The LRU walk would otherwise delete the key we just recorded once
+        // the map is over cap and that key sits at the front of iteration
+        // order (the break at oldest === source).
+        const limiter = new RateLimiter({ windowMs: 60000, maxRequests: 100, maxTrackedSources: 5 });
+        limiter.maxTrackedSources = 0;
+        expect(limiter.isLimitedByKey('only-source')).toBe(false);
+        expect(limiter._requestLog.has('only-source')).toBe(true);
+        expect(limiter._requestLog.size).toBe(1);
+    });
+});

--- a/tests/webServer.test.js
+++ b/tests/webServer.test.js
@@ -339,6 +339,7 @@ describe('WebServer', () => {
             expect(res.status).toBe(200);
             expect(res.body.test).toBe(true);
             expect(res.body.labels.count).toBe(2);
+            expect(res.body.labels).not.toHaveProperty('filePath');
         });
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up hardening batch after the previous master landings. Five focused commits, no version bump.

## Changes

- Validate SIGUSR1 / `systemctl reload` the same way as startup, and restore the previous config cache when the new file would have aborted boot.
- Redact keypad echoes in the remaining event-parse warning, throw, and unparsed-measurement debug paths.
- Drop `labels.filePath` from `GET /api/status` (the dashboard already shipped count-only).
- Cover EventPublisher shutdown, `security_panel` readings, cover `cancelRamp`, and RateLimiter defaults / missing-socket / self-eviction.
- Add runtime-only schema tunables for native-aircon setpoint debounce and Supervisor ingress discovery timeout/attempts/initial backoff. Defaults match the previous literals; not add-on options.

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification

## Checklist

- [ ] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [ ] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

