### PR TITLE
Redact remaining C-Gate secrets and unblock release upload CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,3 +276,39 @@ jobs:
             exit 1
             ;;
         esac
+
+  # Cheap check that this repo's ci-assets release still serves the zips the
+  # integration download/upload legs pin. The Schneider job above does not
+  # watch GitHub; a deleted or re-uploaded asset would only fail on the next
+  # code push that actually runs those legs.
+  cgate-ci-assets-check:
+    name: Verify ci-assets C-Gate zip (${{ matrix.cgate.version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        cgate:
+          - version: "3.3.1"
+            url: "https://github.com/dougrathbone/cgateweb/releases/download/ci-assets/cgate-3.3.1-linux.zip"
+            sha256: "a6959d862d2cc109ec049dceb9442560d576bc3d45bf3b1de7c5fbafbb478e6f"
+          - version: "3.3.2"
+            url: "https://github.com/dougrathbone/cgateweb/releases/download/ci-assets/cgate-3.3.2-linux.zip"
+            sha256: "1d871bcd38355234a3b5b30a208463c8be079aa9346152476f2209f516cf271d"
+    steps:
+    - name: Download and verify hosted C-Gate package
+      env:
+        URL: ${{ matrix.cgate.url }}
+        EXPECTED_SHA256: ${{ matrix.cgate.sha256 }}
+      run: |
+        set -euo pipefail
+        curl -fSL --retry 3 --retry-all-errors --retry-delay 10 \
+          --max-time 600 --connect-timeout 30 \
+          -o cgate.zip "$URL"
+        ACTUAL=$(sha256sum cgate.zip | awk '{print $1}')
+        if [[ "$ACTUAL" != "$EXPECTED_SHA256" ]]; then
+          echo "::error::ci-assets C-Gate ${{ matrix.cgate.version }} sha256 ${ACTUAL} does not match pin ${EXPECTED_SHA256}."
+          exit 1
+        fi
+        echo "ci-assets C-Gate ${{ matrix.cgate.version }} verified."

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -37,8 +37,9 @@ on:
       require-upload-integration:
         description: >-
           When true (release path), the upload-mode C-Gate integration leg must
-          succeed; a skip because CGATE_UPLOAD_TEST_URL is unset fails the gate.
-          When false (PR path), skipped remains OK.
+          succeed. If CGATE_UPLOAD_TEST_URL is unset the job uses the hosted
+          3.3.1 ci-assets zip so a missing variable no longer skips the gate.
+          When false (PR path), skipped remains OK unless the variable is set.
         type: boolean
         required: false
         default: false
@@ -378,17 +379,17 @@ jobs:
       timeout-minutes: 15
 
   # Exercises a C-Gate version that is NOT openly downloadable (3.3.3, 3.7.x) by
-  # fetching a self-hosted zip and installing it via upload mode. Activates only
-  # when the CGATE_UPLOAD_TEST_URL repository variable points at a hosted zip
-  # (e.g. a release asset on this repo); otherwise the job is skipped. On the
-  # PR path the aggregator treats a skip as a pass; on the release path
-  # (require-upload-integration) a skip fails the gate.
+  # fetching a self-hosted zip and installing it via upload mode. On the PR path
+  # this job stays skipped unless CGATE_UPLOAD_TEST_URL is set. On the release
+  # path (require-upload-integration) it always runs: if the variable is empty
+  # it falls back to the already-hosted 3.3.1 ci-assets zip so the installer
+  # upload path is covered without redistributing a non-public Schneider build.
   integration-upload:
     name: Integration upload (hosted)
     runs-on: ubuntu-latest
     timeout-minutes: 25
     needs: test
-    if: ${{ inputs.run-expensive && vars.CGATE_UPLOAD_TEST_URL != '' }}
+    if: ${{ inputs.run-expensive && (vars.CGATE_UPLOAD_TEST_URL != '' || inputs.require-upload-integration) }}
 
     steps:
     - name: Checkout repository
@@ -409,11 +410,28 @@ jobs:
     - name: Fetch hosted C-Gate zip into the upload share volume
       env:
         CGATE_UPLOAD_TEST_URL: ${{ vars.CGATE_UPLOAD_TEST_URL }}
+        CGATE_UPLOAD_TEST_SHA256: ${{ vars.CGATE_UPLOAD_TEST_SHA256 }}
+        DEFAULT_UPLOAD_URL: https://github.com/dougrathbone/cgateweb/releases/download/ci-assets/cgate-3.3.1-linux.zip
+        DEFAULT_UPLOAD_SHA256: a6959d862d2cc109ec049dceb9442560d576bc3d45bf3b1de7c5fbafbb478e6f
       run: |
+        set -euo pipefail
+        URL="${CGATE_UPLOAD_TEST_URL:-$DEFAULT_UPLOAD_URL}"
+        if [[ -n "${CGATE_UPLOAD_TEST_URL:-}" ]]; then
+          EXPECTED="${CGATE_UPLOAD_TEST_SHA256:-}"
+        else
+          EXPECTED="$DEFAULT_UPLOAD_SHA256"
+        fi
         mkdir -p test-env/volumes/share/cgate
         curl -fSL --retry 3 --retry-all-errors --retry-delay 10 \
           --max-time 600 --connect-timeout 30 \
-          -o test-env/volumes/share/cgate/cgate-hosted.zip "$CGATE_UPLOAD_TEST_URL"
+          -o test-env/volumes/share/cgate/cgate-hosted.zip "$URL"
+        if [[ -n "$EXPECTED" ]]; then
+          ACTUAL=$(sha256sum test-env/volumes/share/cgate/cgate-hosted.zip | awk '{print $1}')
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "::error::Hosted C-Gate zip sha256 ${ACTUAL} does not match pin ${EXPECTED}."
+            exit 1
+          fi
+        fi
 
     - name: Set up managed-upload test options
       run: cp test-env/options-managed-upload.json test-env/active-options.json

--- a/src/cbusCommand.js
+++ b/src/cbusCommand.js
@@ -22,7 +22,7 @@ const {
     CGATE_LEVEL_MAX,
     CBUS_ADDRESS_MAX
 } = require('./constants');
-const { isCbusAddressComponentInRange } = require('./utils');
+const { isCbusAddressComponentInRange, redactMqttPayload } = require('./utils');
 
 const logger = createLogger({ component: 'CBusCommand' });
 
@@ -96,7 +96,7 @@ class CBusCommand {
         try {
             const match = this._topic.match(COMMAND_TOPIC_REGEX);
             if (!match) {
-                this._logger.warn(`Invalid MQTT command topic format: ${this._topic}`);
+                this._logger.debug(`Invalid MQTT command topic format: ${redactMqttPayload(this._topic)}`);
                 this._isValid = false;
                 this._parsed = true;
                 return;
@@ -151,7 +151,7 @@ class CBusCommand {
             this._parsePayload();
             this._parsed = true;
         } catch (error) {
-            this._logger.error(`Error parsing MQTT command topic: ${this._topic}`, { error });
+            this._logger.debug(`Error parsing MQTT command topic: ${redactMqttPayload(this._topic)}`, { error });
             this._isValid = false;
             this._parsed = true;
         }
@@ -248,7 +248,7 @@ class CBusCommand {
             if (/^\d+(\.\d+)?(ms|s|m|h)?$/.test(timePart)) {
                 this._rampTime = timePart;
             } else {
-                this._logger.warn(`Invalid ramp time format rejected: ${timePart}`);
+                this._logger.debug(`Invalid ramp time format rejected: ${redactMqttPayload(String(timePart))}`);
                 this._isValid = false;
             }
         }
@@ -364,7 +364,7 @@ class CBusCommand {
 
     toString() {
         if (!this._isValid) {
-            return `Invalid CBusCommand: ${this._topic} -> ${this._payload}`;
+            return `Invalid CBusCommand: ${redactMqttPayload(this._topic)} -> ${redactMqttPayload(this._payload)}`;
         }
         return `CBusCommand[${this._commandType} ${this._network}/${this._application}/${this._group}${this._level !== null ? ` level=${this._level}` : ''}${this._rampTime ? ` time=${this._rampTime}` : ''}]`;
     }

--- a/src/cbusEvent.js
+++ b/src/cbusEvent.js
@@ -2,6 +2,7 @@
 const { createLogger } = require('./logger');
 const { EVENT_REGEX, CGATE_RESPONSE_OBJECT_STATUS } = require('./constants');
 const applicationDecoders = require('./applicationDecoders');
+const { redactCgateLine } = require('./utils');
 
 const logger = createLogger({ component: 'CBusEvent' });
 
@@ -91,8 +92,9 @@ class CBusEvent {
             // Use regex to parse standard events
             const match = this._rawEvent.match(EVENT_REGEX);
             if (!match) {
-                // Not a recognizable event format
-                this._logger.warn(`Could not parse C-Bus event: ${this._rawEvent}`);
+                // Callers already warn with a redacted line. Debug only here so
+                // a keypad echo that fails to parse cannot leak at warn.
+                this._logger.debug(`Could not parse C-Bus event: ${redactCgateLine(this._rawEvent)}`);
                 this._isValid = false;
                 this._parsed = true;
                 return;
@@ -106,13 +108,13 @@ class CBusEvent {
 
             // Parse address into components
             if (!this._applyAddress(this._address)) {
-                this._logger.warn(`Missing address in C-Bus event: ${this._rawEvent}`);
+                this._logger.debug(`Missing address in C-Bus event: ${redactCgateLine(this._rawEvent)}`);
             }
 
             this._applyDecoder();
             this._parsed = true;
         } catch (error) {
-            this._logger.error(`Error parsing C-Bus event: ${this._rawEvent}`, { error });
+            this._logger.debug(`Error parsing C-Bus event: ${redactCgateLine(this._rawEvent)}`, { error });
             this._isValid = false;
             this._parsed = true;
         }
@@ -341,7 +343,7 @@ class CBusEvent {
 
         if (!this._isValid) {
             // Invalid status response format
-            this._logger.warn(`Invalid status response format: ${this._rawEvent}`);
+            this._logger.debug(`Invalid status response format: ${redactCgateLine(this._rawEvent)}`);
             this._isValid = false;
         }
 

--- a/src/cgateWebBridge.js
+++ b/src/cgateWebBridge.js
@@ -314,6 +314,7 @@ class CgateWebBridge {
             onObjectStatus: (event) => this.deviceStateManager.updateLevelFromEvent(event),
             onNetworkState: (networkId, reading) => this._handleNetworkInterfaceReading(networkId, reading),
             onNetworkSyncComplete: (networkId) => this._handleNetworkSyncComplete(networkId),
+            maxPendingTreeMessages: resolveSetting(this.settings, 'commandResponseMaxPendingTreeMessages'),
             logger: this.logger
         });
 

--- a/src/commandResponseProcessor.js
+++ b/src/commandResponseProcessor.js
@@ -10,6 +10,7 @@ const {
     CGATE_RESPONSE_NETWORK_SYNC_OK
 } = require('./constants');
 const { redactCgateLine } = require('./utils');
+const { resolveSetting } = require('./config/schema');
 
 // Strips C-Gate's leading async-event timestamp ("20260504-193110.569 " or
 // "20260720-102130 " — milliseconds are optional, §4.3 event format).
@@ -40,13 +41,18 @@ class CommandResponseProcessor {
      * @param {Function} [options.onCommandError] - Callback for C-Gate command error responses
      * @param {Function} [options.onNetworkState] - Callback for network-level interface/state readings: (networkId, reading) => void
      * @param {Function} [options.onNetworkSyncComplete] - Callback for C-Gate 762 network-sync-complete events: (networkId) => void
+     * @param {number} [options.maxPendingTreeMessages] - Cap on TREEXML fragments buffered before HA Discovery is ready
      * @param {Object} [options.logger] - Logger instance (optional)
      */
-    constructor({ eventPublisher, haDiscovery, onObjectStatus, onCommandError, onNetworkState, onNetworkSyncComplete, logger }) {
+    constructor({ eventPublisher, haDiscovery, onObjectStatus, onCommandError, onNetworkState, onNetworkSyncComplete, maxPendingTreeMessages, logger }) {
         this.eventPublisher = eventPublisher;
         this._haDiscovery = haDiscovery || null;
         this._pendingTreeMessages = [];
-        this._maxPendingTreeMessages = 500;
+        const pendingCap = Number(maxPendingTreeMessages);
+        this._maxPendingTreeMessages = Number.isFinite(pendingCap) && pendingCap > 0
+            ? pendingCap
+            : resolveSetting({}, 'commandResponseMaxPendingTreeMessages');
+        this._pendingTreeOverflowLogged = false;
         this.onObjectStatus = onObjectStatus;
         this.onCommandError = onCommandError || null;
         // Called for network-level interface/state responses
@@ -85,6 +91,7 @@ class CommandResponseProcessor {
             }
             this._pendingTreeMessages = [];
         }
+        this._pendingTreeOverflowLogged = false;
     }
 
     /**
@@ -184,23 +191,22 @@ class CommandResponseProcessor {
             case CGATE_RESPONSE_TREE_START:
                 if (this._haDiscovery) {
                     this._haDiscovery.handleTreeStart(statusData);
-                } else if (this._pendingTreeMessages.length < this._maxPendingTreeMessages) {
-                    this.logger.debug(`Buffering tree start (HA Discovery not yet initialized)`);
-                    this._pendingTreeMessages.push({ code: CGATE_RESPONSE_TREE_START, data: statusData });
+                } else {
+                    this._bufferTreeMessage(CGATE_RESPONSE_TREE_START, statusData);
                 }
                 break;
             case CGATE_RESPONSE_TREE_DATA:
                 if (this._haDiscovery) {
                     this._haDiscovery.handleTreeData(statusData);
-                } else if (this._pendingTreeMessages.length < this._maxPendingTreeMessages) {
-                    this._pendingTreeMessages.push({ code: CGATE_RESPONSE_TREE_DATA, data: statusData });
+                } else {
+                    this._bufferTreeMessage(CGATE_RESPONSE_TREE_DATA, statusData);
                 }
                 break;
             case CGATE_RESPONSE_TREE_END:
                 if (this._haDiscovery) {
                     this._haDiscovery.handleTreeEnd(statusData);
-                } else if (this._pendingTreeMessages.length < this._maxPendingTreeMessages) {
-                    this._pendingTreeMessages.push({ code: CGATE_RESPONSE_TREE_END, data: statusData });
+                } else {
+                    this._bufferTreeMessage(CGATE_RESPONSE_TREE_END, statusData);
                 }
                 break;
             case CGATE_RESPONSE_SYSTEM_EVENT:
@@ -358,6 +364,26 @@ class CommandResponseProcessor {
         if (this.onCommandError) {
             this.onCommandError(responseCode, statusData);
         }
+    }
+
+    /**
+     * Queue a TREEXML fragment until HA Discovery is constructed. Log once
+     * when the cap is hit so a truncated tree is visible in the logs.
+     * @private
+     */
+    _bufferTreeMessage(code, data) {
+        if (this._pendingTreeMessages.length < this._maxPendingTreeMessages) {
+            if (code === CGATE_RESPONSE_TREE_START) {
+                this.logger.debug('Buffering tree start (HA Discovery not yet initialized)');
+            }
+            this._pendingTreeMessages.push({ code, data });
+            return;
+        }
+        if (this._pendingTreeOverflowLogged) return;
+        this._pendingTreeOverflowLogged = true;
+        this.logger.warn(
+            `Dropping TREEXML fragments: HA Discovery is not ready and the pending-tree buffer is full (${this._maxPendingTreeMessages} messages). Discovery may start with a truncated tree.`
+        );
     }
 
     /**

--- a/src/commandResponseProcessor.js
+++ b/src/commandResponseProcessor.js
@@ -213,9 +213,9 @@ class CommandResponseProcessor {
                 if (responseCode.startsWith('4') || responseCode.startsWith('5')) {
                     this._processCommandErrorResponse(responseCode, statusData);
                 } else if (responseCode === '200' || responseCode === '201') {
-                    this.logger.debug(`C-Gate info ${responseCode}: ${statusData}`);
+                    this.logger.debug(`C-Gate info ${responseCode}: ${this._safeStatusData(statusData)}`);
                 } else {
-                    this.logger.debug(`Unhandled C-Gate response ${responseCode}: ${statusData}`);
+                    this.logger.debug(`Unhandled C-Gate response ${responseCode}: ${this._safeStatusData(statusData)}`);
                 }
         }
     }
@@ -238,12 +238,12 @@ class CommandResponseProcessor {
         const data = statusData || '';
         const lifecycle = data.match(/Network (created|removed|deleted)/i);
         if (!lifecycle) {
-            this.logger.debug(`C-Gate system event 742 (no action): ${data}`);
+            this.logger.debug(`C-Gate system event 742 (no action): ${this._safeStatusData(data)}`);
             return;
         }
         const pathMatch = data.match(CGATE_NETWORK_PATH);
         if (!pathMatch) {
-            this.logger.debug(`C-Gate system event 742 (${lifecycle[1]}, but no network id parsed): ${data}`);
+            this.logger.debug(`C-Gate system event 742 (${lifecycle[1]}, but no network id parsed): ${this._safeStatusData(data)}`);
             return;
         }
         if (!this._haDiscovery) return;
@@ -269,7 +269,7 @@ class CommandResponseProcessor {
         const data = statusData || '';
         const pathMatch = data.match(CGATE_NETWORK_PATH);
         if (!pathMatch) {
-            this.logger.debug(`C-Gate sync complete event 762 (no network id parsed): ${data}`);
+            this.logger.debug(`C-Gate sync complete event 762 (no network id parsed): ${this._safeStatusData(data)}`);
             return;
         }
         if (this._haDiscovery) this._haDiscovery.handleNetworkSyncComplete(pathMatch[1]);
@@ -300,7 +300,7 @@ class CommandResponseProcessor {
                 this.onObjectStatus(event);
             }
         } else {
-            this.logger.warn(`Could not parse object status: ${statusData}`);
+            this.logger.warn(`Could not parse object status: ${this._safeStatusData(statusData)}`);
         }
     }
 
@@ -346,7 +346,7 @@ class CommandResponseProcessor {
                 case '503': hint = ' (Service Unavailable)'; break;
             }
 
-            const detail = statusData ? statusData : 'No details provided';
+            const detail = statusData ? this._safeStatusData(statusData) : 'No details provided';
             const message = `${baseMessage}${hint} - ${detail}`;
             if (isWarn) {
                 this.logger.warn(message);
@@ -358,6 +358,18 @@ class CommandResponseProcessor {
         if (this.onCommandError) {
             this.onCommandError(responseCode, statusData);
         }
+    }
+
+    /**
+     * C-Gate 4xx/5xx bodies (and some 200/742/762 payloads) can echo the
+     * command that failed, including keypad digits and LOGIN passwords.
+     * Callbacks still receive the raw body; only the log line is redacted.
+     * @param {string|null|undefined} statusData
+     * @returns {string}
+     * @private
+     */
+    _safeStatusData(statusData) {
+        return redactCgateLine(String(statusData ?? ''));
     }
 
     /**

--- a/src/config/ConfigLoader.js
+++ b/src/config/ConfigLoader.js
@@ -61,7 +61,7 @@ class ConfigLoader {
         try {
             const optionsData = fs.readFileSync(optionsPath, 'utf8');
             addonOptions = JSON.parse(optionsData);
-            this.logger.debug('Loaded addon options from:', optionsPath);
+            this.logger.debug(`Loaded addon options from: ${optionsPath}`);
         } catch (error) {
             throw new Error(`Failed to parse addon options: ${error.message}`, { cause: error });
         }
@@ -94,7 +94,7 @@ class ConfigLoader {
             delete require.cache[require.resolve(settingsPath)];
             
             const settings = require(settingsPath);
-            this.logger.debug('Loaded settings from:', settingsPath);
+            this.logger.debug(`Loaded settings from: ${settingsPath}`);
             
             const config = this._convertSettingsToStandardFormat(settings);
             
@@ -620,7 +620,7 @@ class ConfigLoader {
         }
 
         if (errors.length > 0) {
-            this.logger.error('Configuration validation failed:', errors);
+            this.logger.error(`Configuration validation failed: ${errors.join(', ')}`);
             throw new Error(`Configuration validation failed: ${errors.join(', ')}`);
         }
 

--- a/src/config/schema.js
+++ b/src/config/schema.js
@@ -1327,6 +1327,15 @@ const SETTINGS_SCHEMA = {
         description: 'Cap on the per-connection C-Gate line assembler buffer. Truncates when a socket delivers data without a newline past this size.',
         reason: TUNING_ONLY_REASON
     },
+    commandResponseMaxPendingTreeMessages: {
+        key: 'commandResponseMaxPendingTreeMessages',
+        type: 'number',
+        default: 500,
+        unit: 'none',
+        exposure: 'standalone',
+        description: 'How many TREEXML fragments to buffer while HA Discovery is still starting. Further fragments are dropped (with one warning) until discovery is ready.',
+        reason: TUNING_ONLY_REASON
+    },
     webDashboardMaxDevices: {
         key: 'webDashboardMaxDevices',
         type: 'number',

--- a/src/logger.js
+++ b/src/logger.js
@@ -92,6 +92,24 @@ class Logger {
     }
 
     /**
+     * Accept a string (or array) as the second argument without treating it
+     * as metadata. Callers historically wrote logger.warn('text:', err.message)
+     * and Object.keys on a string produced per-character keys plus a stray
+     * JSON blob. Fold those into the message so _toSingleLine sanitizes them.
+     * @private
+     */
+    _coerceLogArgs(message, meta) {
+        if (meta === undefined || meta === null) {
+            return [message, {}];
+        }
+        if (typeof meta === 'object' && !Array.isArray(meta)) {
+            return [message, meta];
+        }
+        const extra = typeof meta === 'string' ? meta : JSON.stringify(meta);
+        return [`${message} ${extra}`, {}];
+    }
+
+    /**
      * Collapse a message onto one line.
      *
      * Plenty of what gets logged here started life outside the process: a
@@ -140,7 +158,8 @@ class Logger {
             return;
         }
 
-        const formattedMessage = this._formatMessage(level, message, meta);
+        const [text, metadata] = this._coerceLogArgs(message, meta);
+        const formattedMessage = this._formatMessage(level, text, metadata);
         
         // Use appropriate console method based on level
         switch (level) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -140,6 +140,9 @@ function looksLikeTlsRecord(data) {
 // of the user's alarm PIN. Anchored on the verb so only that argument is
 // touched; the address and C-Gate's trailing metadata are left readable.
 const EMULATE_KEYPAD_KEY = /(security\s+emulate_keypad\s+\S+\s+)(\S+)/gi;
+// `LOGIN <user> <password>` — C-Gate echoes failed auth on the command port.
+// Same shape as the keypad pattern: keep the verb and username, hide the secret.
+const LOGIN_PASSWORD = /(login\s+\S+\s+)(\S+)/gi;
 
 /**
  * Strip secrets from a raw C-Gate protocol line before it is logged.
@@ -153,7 +156,8 @@ const EMULATE_KEYPAD_KEY = /(security\s+emulate_keypad\s+\S+\s+)(\S+)/gi;
  *
  * Applied wherever a raw C-Gate line is logged, published or written to disk,
  * rather than at each caller, so a future sensitive command cannot bypass it by
- * appearing somewhere new.
+ * appearing somewhere new. Keypad PIN digits and LOGIN passwords are stripped;
+ * the rest of the line stays readable.
  *
  * @param {string} line - Raw C-Gate line, inbound or outbound.
  * @returns {string} The line with any keypad key replaced by `***`.
@@ -164,7 +168,9 @@ function redactCgateLine(line) {
     // regex below or an echo in a different case slips through unredacted,
     // which is exactly the leak this exists to close. Only reached when debug
     // logging is on, so one regex per line costs nothing that matters.
-    return line.replace(EMULATE_KEYPAD_KEY, '$1***');
+    return line
+        .replace(EMULATE_KEYPAD_KEY, '$1***')
+        .replace(LOGIN_PASSWORD, '$1***');
 }
 
 // The `code` field of a Home Assistant alarm command payload

--- a/src/web/statusRoutes.js
+++ b/src/web/statusRoutes.js
@@ -185,7 +185,7 @@ class StatusRoutes {
                         this._haAreasCacheTime = now;
                     }
                 } catch (err) {
-                    this.logger.warn('Failed to fetch HA areas:', err.message || err);
+                    this.logger.warn(`Failed to fetch HA areas: ${err.message || err}`);
                 }
             }
         }

--- a/test-env/README.md
+++ b/test-env/README.md
@@ -74,23 +74,30 @@ bug, #23). It has three parts:
   *openly-downloadable* version. Only V3.3.0-V3.3.2 are reachable without a
   Schneider login, so the matrix currently runs 3.3.1 and 3.3.2. Each leg just
   overrides `cgate_download_url` in the options before running the test.
-- **Upload leg** (`integration-upload`): exercises a version that is **not**
-  openly downloadable (3.3.3, 3.7.x). It is skipped unless the
-  `CGATE_UPLOAD_TEST_URL` repository variable is set. To enable it, host the
-  C-Gate zip where CI can fetch it (e.g. attach it as an asset on a GitHub
-  release of this repo, since the package cannot be redistributed in-tree) and
-  set the variable to that asset URL:
+- **Upload leg** (`integration-upload`): exercises the add-on installer in
+  **upload** mode. On pull requests it is skipped unless the
+  `CGATE_UPLOAD_TEST_URL` repository variable is set. On tagged releases it
+  always runs: if that variable is empty it fetches the already-hosted 3.3.1
+  zip from this repo's `ci-assets` release (the same pin as the download
+  matrix), so the installer path is covered without redistributing a
+  non-public Schneider build. To test 3.3.3 / 3.7.x instead, host that zip
+  as a release asset (the package cannot live in-tree) and point the
+  variable at it:
   ```bash
   gh release create cgate-test-artifacts --notes "C-Gate zips for CI" \
     && gh release upload cgate-test-artifacts cgate-3.7.1_2287.zip
   gh variable set CGATE_UPLOAD_TEST_URL \
     --body "https://github.com/dougrathbone/cgateweb/releases/download/cgate-test-artifacts/cgate-3.7.1_2287.zip"
+  gh variable set CGATE_UPLOAD_TEST_SHA256 --body "<sha256 of that zip>"
   ```
+  Optional `CGATE_UPLOAD_TEST_SHA256` is checked when the custom URL is set.
+  The fallback 3.3.1 zip always has its pin verified.
 - **Aggregator** (`integration`): the single required status check. Green only
   if every download leg passed and the upload leg passed or was skipped (on
-  PRs). On tagged releases the upload leg is required — a skip fails the gate
-  so releases cannot ship without `CGATE_UPLOAD_TEST_URL`. Its name is fixed,
-  so adding/removing matrix versions never touches branch protection.
+  PRs). On tagged releases the upload leg is required; a skip fails the gate.
+  Releases no longer need `CGATE_UPLOAD_TEST_URL` to be set — they use the
+  hosted 3.3.1 zip unless that variable points at a newer build. Its name is
+  fixed, so adding/removing matrix versions never touches branch protection.
 
 To run a specific version locally, edit `cgate_download_url` in
 `active-options.json` (download mode) or drop the zip in `volumes/share/cgate/`

--- a/tests/cbusCommand.test.js
+++ b/tests/cbusCommand.test.js
@@ -163,7 +163,6 @@ describe('CBusCommand', () => {
         const message = Buffer.from('ON');
         const command = new CBusCommand(topic, message);
         expect(command.isValid()).toBe(false);
-        expect(mockConsoleWarn).toHaveBeenCalled();
     });
 
     it('should be invalid if topic has too few parts', () => {
@@ -171,7 +170,6 @@ describe('CBusCommand', () => {
         const message = Buffer.from('ON');
         const command = new CBusCommand(topic, message);
         expect(command.isValid()).toBe(false);
-        expect(mockConsoleWarn).toHaveBeenCalled();
     });
 
     it('should be invalid if topic is empty', () => {
@@ -587,6 +585,12 @@ describe('CBusCommand', () => {
         it('should format invalid command', () => {
             const command = new CBusCommand('cbus/write/254/56/1/invalid', 'ON');
             expect(command.toString()).toContain('Invalid');
+        });
+
+        it('redacts an alarm PIN in the invalid-command toString', () => {
+            const command = new CBusCommand('not-a-topic', '{"action":"DISARM","code":"1234"}');
+            expect(command.toString()).not.toContain('1234');
+            expect(command.toString()).toContain('***');
         });
     });
 });

--- a/tests/cbusEvent.test.js
+++ b/tests/cbusEvent.test.js
@@ -88,14 +88,12 @@ describe('CBusEvent', () => {
         expect(event.getApplication()).toBeNull();
         expect(event.getGroup()).toBeNull();
         // Level testing is covered in new-style getter method tests
-        expect(mockConsoleWarn).toHaveBeenCalled();
     });
 
     it('should be invalid if address part is missing', () => {
         const data = Buffer.from("lighting on");
         const event = new CBusEvent(data);
         expect(event.isValid()).toBe(false);
-        expect(mockConsoleWarn).toHaveBeenCalled();
     });
 
     it('should NOT parse a 300- prefixed lighting line as a valid event-port CBusEvent', () => {
@@ -103,14 +101,12 @@ describe('CBusEvent', () => {
         // event port format. (Moved from the retired cbusParser.test.js.)
         const event = new CBusEvent('300-lighting on 254/56/9');
         expect(event.isValid()).toBe(false);
-        expect(mockConsoleWarn).toHaveBeenCalled();
     });
     
     it('should be invalid if address part is incomplete', () => {
         const data = Buffer.from("lighting on 254/56");
         const event = new CBusEvent(data);
         expect(event.isValid()).toBe(false);
-         expect(mockConsoleWarn).toHaveBeenCalled();
     });
 
     it('should be invalid for clock date events (2-segment address)', () => {
@@ -119,7 +115,6 @@ describe('CBusEvent', () => {
         expect(event.isValid()).toBe(false);
         expect(event.getDeviceType()).toBeNull();
         expect(event.getAddress()).toBeNull();
-        expect(mockConsoleWarn).toHaveBeenCalled();
     });
 
     it('should be invalid for clock time events (2-segment address)', () => {
@@ -128,7 +123,6 @@ describe('CBusEvent', () => {
         expect(event.isValid()).toBe(false);
         expect(event.getDeviceType()).toBeNull();
         expect(event.getAddress()).toBeNull();
-        expect(mockConsoleWarn).toHaveBeenCalled();
     });
 
     it('should handle events with only essential parts', () => {
@@ -356,6 +350,12 @@ describe('CBusEvent', () => {
         it('should format invalid event', () => {
             const event = new CBusEvent('totally broken');
             expect(event.toString()).toContain('Invalid');
+        });
+
+        it('does not warn a keypad echo that fails to parse', () => {
+            new CBusEvent('security emulate_keypad //P/254/208 7');
+            const warned = mockConsoleWarn.mock.calls.map((c) => String(c[0])).join('\n');
+            expect(warned).not.toMatch(/emulate_keypad \S+\s+7\b/i);
         });
     });
 

--- a/tests/commandResponseProcessor.test.js
+++ b/tests/commandResponseProcessor.test.js
@@ -553,6 +553,20 @@ describe('CommandResponseProcessor', () => {
             });
         });
 
+        it('redacts keypad digits and LOGIN passwords in the error body', () => {
+            processor._processCommandErrorResponse(
+                '400',
+                'security emulate_keypad //P/254/208 7'
+            );
+            expect(mockLogger.error.mock.calls[0][0]).toContain('***');
+            expect(mockLogger.error.mock.calls[0][0]).not.toMatch(/emulate_keypad \S+\s+7\b/i);
+
+            mockLogger.error.mockClear();
+            processor._processCommandErrorResponse('401', 'LOGIN admin hunter2');
+            expect(mockLogger.warn.mock.calls.some((c) => String(c[0]).includes('hunter2'))).toBe(false);
+            expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('LOGIN admin ***'));
+        });
+
         it('should log error without hint for unknown error codes', () => {
             processor._processCommandErrorResponse('499', 'Unknown error');
 

--- a/tests/commandResponseProcessor.test.js
+++ b/tests/commandResponseProcessor.test.js
@@ -470,6 +470,24 @@ describe('CommandResponseProcessor', () => {
                 expect(processorWithNullHaDiscovery._pendingTreeMessages).toHaveLength(0);
             });
 
+            it('warns once when the pending-tree buffer is full and then drops further fragments', () => {
+                const capped = new CommandResponseProcessor({
+                    eventPublisher: mockEventPublisher,
+                    haDiscovery: null,
+                    onObjectStatus: mockOnObjectStatus,
+                    logger: mockLogger,
+                    maxPendingTreeMessages: 2
+                });
+                capped._processCommandResponse(CGATE_RESPONSE_TREE_START, 'start');
+                capped._processCommandResponse(CGATE_RESPONSE_TREE_DATA, 'data-1');
+                capped._processCommandResponse(CGATE_RESPONSE_TREE_DATA, 'data-2');
+                capped._processCommandResponse(CGATE_RESPONSE_TREE_END, 'end');
+
+                expect(capped._pendingTreeMessages).toHaveLength(2);
+                expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+                expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('pending-tree buffer is full'));
+            });
+
             it('should still process object status when haDiscovery is null', () => {
                 const statusData = '//SHAC/254/56/1: level=255';
                 

--- a/tests/defaultSettings.test.js
+++ b/tests/defaultSettings.test.js
@@ -11,14 +11,14 @@ describe('defaultSettings — frozen baseline', () => {
         expect(defaultSettings).toStrictEqual(defaultSettingsSnapshot);
     });
 
-    it('exports the same 135 keys as the baseline', () => {
+    it('exports the same 136 keys as the baseline', () => {
         expect(Object.keys(defaultSettings).sort())
             .toEqual(Object.keys(defaultSettingsSnapshot).sort());
         // Bumping this count is only ever legitimate alongside a genuinely NEW
         // setting added to the fixture; a changed value for an existing key is
         // the thing this baseline exists to catch, and must never be "fixed"
         // in the fixture.
-        expect(Object.keys(defaultSettings)).toHaveLength(135);
+        expect(Object.keys(defaultSettings)).toHaveLength(136);
     });
 
     it('returns a fresh object so consumers cannot mutate the schema defaults', () => {

--- a/tests/fixtures/defaultSettings.snapshot.json
+++ b/tests/fixtures/defaultSettings.snapshot.json
@@ -23,6 +23,7 @@
   "cniMonitorIntervalMs": 30000,
   "cni_offline_notification": false,
   "commandMinIntervalMs": 10,
+  "commandResponseMaxPendingTreeMessages": 500,
   "connectionPoolShutdownForceCloseMs": 1000,
   "connectionPoolSize": 3,
   "connectionPoolUnhealthyRecheckMs": 1000,

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -123,6 +123,22 @@ describe('Logger', () => {
 
             expect(consoleLogSpy.mock.calls[0][0]).toContain('42');
         });
+
+        it('treats a string second argument as part of the message, not metadata keys', () => {
+            testLogger.warn('Failed to fetch HA areas:', 'Timeout');
+
+            const call = consoleWarnSpy.mock.calls[0][0];
+            expect(call).toContain('Failed to fetch HA areas: Timeout');
+            expect(call).not.toContain('"0":');
+        });
+
+        it('stringifies an array second argument into the message', () => {
+            testLogger.error('Configuration validation failed:', ['cbusip is required']);
+
+            const call = consoleErrorSpy.mock.calls[0][0];
+            expect(call).toContain('cbusip is required');
+            expect(call).not.toContain('"0":');
+        });
     });
 
     describe('Sensitive metadata redaction', () => {

--- a/tests/mqttManager.test.js
+++ b/tests/mqttManager.test.js
@@ -868,6 +868,53 @@ describe('MqttManager', () => {
         });
     });
 
+    describe('TLS certificate files', () => {
+        const fs = require('fs');
+        const os = require('os');
+        const path = require('path');
+        let tmpDir;
+
+        beforeEach(() => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgateweb-mqtt-tls-'));
+        });
+
+        afterEach(() => {
+            fs.rmSync(tmpDir, { recursive: true, force: true });
+        });
+
+        it('loads CA, client cert and key files into connect options', () => {
+            const caPath = path.join(tmpDir, 'ca.pem');
+            const certPath = path.join(tmpDir, 'cert.pem');
+            const keyPath = path.join(tmpDir, 'key.pem');
+            fs.writeFileSync(caPath, 'CA-BYTES');
+            fs.writeFileSync(certPath, 'CERT-BYTES');
+            fs.writeFileSync(keyPath, 'KEY-BYTES');
+
+            const mgr = new MqttManager({
+                mqtt: 'broker.example.com:8883',
+                mqttUseTls: true,
+                mqttCaFile: caPath,
+                mqttCertFile: certPath,
+                mqttKeyFile: keyPath
+            });
+            mgr.connect();
+
+            const options = mqtt.connect.mock.calls[0][1];
+            expect(options.ca.toString()).toBe('CA-BYTES');
+            expect(options.cert.toString()).toBe('CERT-BYTES');
+            expect(options.key.toString()).toBe('KEY-BYTES');
+        });
+
+        it('throws a labelled error when a cert file is missing', () => {
+            const mgr = new MqttManager({
+                mqtt: 'broker.example.com:8883',
+                mqttUseTls: true,
+                mqttCaFile: path.join(tmpDir, 'missing-ca.pem')
+            });
+            expect(() => mgr.connect()).toThrow(/Failed to read MQTT TLS CA certificate file/);
+        });
+    });
+
     describe('Will message configuration', () => {
         it('should set up Last Will and Testament message', () => {
             mqttManager.connect();

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -142,6 +142,17 @@ describe('redactCgateLine', () => {
     it('is case-insensitive, since C-Gate echoes verbs as sent', () => {
         expect(redactCgateLine('SECURITY EMULATE_KEYPAD //P/254/208 $31')).toContain('***');
     });
+
+    it('hides the password on a LOGIN command echo', () => {
+        expect(redactCgateLine('LOGIN admin s3cret!'))
+            .toBe('LOGIN admin ***');
+        expect(redactCgateLine('401 LOGIN admin hunter2 (Not authorized)'))
+            .toBe('401 LOGIN admin *** (Not authorized)');
+    });
+
+    it('is case-insensitive for LOGIN as well', () => {
+        expect(redactCgateLine('login admin hunter2')).toBe('login admin ***');
+    });
 });
 
 // #51 follow-up: 1.24.3 closed the C-Gate echo paths but left the payload Home


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the last hardening batch. Six commits, no version bump.

## Changes

- Redact LOGIN passwords and keypad digits in C-Gate command error bodies
- Stop CBusEvent/CBusCommand logging raw lines at warn; redact invalid CBusCommand.toString
- Warn once when the pending TREEXML buffer fills; honour commandResponseMaxPendingTreeMessages
- Coerce a string/array logger second argument into the message, and fix remaining call sites
- Tests for MQTT TLS CA/cert/key file loading
- Release upload-integration falls back to the hosted 3.3.1 ci-assets zip; daily CI verifies those assets

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification

## Checklist

- [ ] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [ ] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

