### PR TITLE
Publish prebuilt Home Assistant images and release v1.28.0

### DIFF
--- a/.github/workflows/hacs-distribution.yml
+++ b/.github/workflows/hacs-distribution.yml
@@ -40,6 +40,114 @@ jobs:
       run-expensive: true
       require-upload-integration: true
 
+  # Publish one architecture-specific tag per build, then combine them into the
+  # generic multi-architecture image that config.yaml tells Supervisor to pull.
+  # The release must not be advertised before every architecture exists.
+  publish-images:
+    name: Publish add-on image (${{ matrix.arch }})
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: quality
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, aarch64, armv7, armhf, i386]
+
+    steps:
+    - name: Checkout source repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Set up QEMU (multi-arch emulation)
+      if: matrix.arch != 'amd64'
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8  # v4.2.0
+
+    - name: Assemble add-on build context
+      run: |
+        mkdir -p ctx
+        cp -r homeassistant-addon/rootfs ctx/
+        cp homeassistant-addon/run.sh ctx/
+        cp homeassistant-addon/Dockerfile ctx/
+        cp -r src public ctx/
+        cp index.js package.json package-lock.json ctx/
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+    - name: Log in to GitHub Container Registry
+      env:
+        GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: echo "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+
+    - name: Build and publish image
+      env:
+        ARCH: ${{ matrix.arch }}
+        VERSION: ${{ github.ref_name }}
+      run: |
+        VERSION=${VERSION#v}
+        case "${ARCH}" in
+          amd64) platform=linux/amd64 ;;
+          aarch64) platform=linux/arm64 ;;
+          armv7) platform=linux/arm/v7 ;;
+          armhf) platform=linux/arm/v6 ;;
+          i386) platform=linux/386 ;;
+          *) echo "Unknown arch ${ARCH}"; exit 1 ;;
+        esac
+        docker buildx build \
+          --platform "$platform" \
+          --build-arg "BUILD_FROM=ghcr.io/home-assistant/${ARCH}-base:3.21" \
+          --build-arg "BUILD_ARCH=${ARCH}" \
+          --build-arg "BUILD_VERSION=${VERSION}" \
+          --build-arg "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+          --build-arg "BUILD_REF=${GITHUB_SHA}" \
+          --provenance=false \
+          --push \
+          -t "ghcr.io/dougrathbone/cgateweb:${VERSION}-${ARCH}" \
+          ctx
+
+  publish-manifest:
+    name: Publish multi-architecture manifest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: publish-images
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c  # v4.2.0
+
+    - name: Log in to GitHub Container Registry
+      env:
+        GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: echo "$GHCR_TOKEN" | docker login ghcr.io --username "$GITHUB_ACTOR" --password-stdin
+
+    - name: Publish manifest
+      env:
+        VERSION: ${{ github.ref_name }}
+      run: |
+        VERSION=${VERSION#v}
+        docker buildx imagetools create \
+          --tag "ghcr.io/dougrathbone/cgateweb:${VERSION}" \
+          "ghcr.io/dougrathbone/cgateweb:${VERSION}-amd64" \
+          "ghcr.io/dougrathbone/cgateweb:${VERSION}-aarch64" \
+          "ghcr.io/dougrathbone/cgateweb:${VERSION}-armv7" \
+          "ghcr.io/dougrathbone/cgateweb:${VERSION}-armhf" \
+          "ghcr.io/dougrathbone/cgateweb:${VERSION}-i386"
+
+    - name: Verify users can pull the image anonymously
+      env:
+        VERSION: ${{ github.ref_name }}
+      run: |
+        VERSION=${VERSION#v}
+        docker logout ghcr.io
+        docker buildx imagetools inspect "ghcr.io/dougrathbone/cgateweb:${VERSION}"
+
   build-and-deploy:
     timeout-minutes: 20
     permissions:
@@ -54,7 +162,7 @@ jobs:
     # is usually skipped, and a skipped upstream used to skip this job too. With
     # one upstream that reports success on skips, the plain form is correct.
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: quality
+    needs: publish-manifest
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/hacs-distribution.yml
+++ b/.github/workflows/hacs-distribution.yml
@@ -140,13 +140,34 @@ jobs:
           "ghcr.io/dougrathbone/cgateweb:${VERSION}-armhf" \
           "ghcr.io/dougrathbone/cgateweb:${VERSION}-i386"
 
+    # GHCR packages default to private on first publish. Supervisor pulls
+    # anonymously, so a private package would make the advertised version
+    # uninstallable. This is a no-op once the package is already public.
+    - name: Make the package public
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        if ! gh api --method POST \
+          "/user/packages/container/cgateweb/visibility" \
+          -f visibility=public; then
+          echo "::error::Could not make ghcr.io/dougrathbone/cgateweb public. Open Package settings and set visibility to Public, then re-run this workflow."
+          exit 1
+        fi
+
     - name: Verify users can pull the image anonymously
       env:
         VERSION: ${{ github.ref_name }}
       run: |
         VERSION=${VERSION#v}
         docker logout ghcr.io
-        docker buildx imagetools inspect "ghcr.io/dougrathbone/cgateweb:${VERSION}"
+        for i in 1 2 3 4 5; do
+          if docker buildx imagetools inspect "ghcr.io/dougrathbone/cgateweb:${VERSION}"; then
+            exit 0
+          fi
+          sleep $((i * 5))
+        done
+        echo "::error::Anonymous inspect of ghcr.io/dougrathbone/cgateweb:${VERSION} failed. The package must be public."
+        exit 1
 
   build-and-deploy:
     timeout-minutes: 20

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -24,7 +24,7 @@ If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.co
 
 ### Changed
 
-- **Home Assistant now downloads a tested prebuilt image** instead of building the add-on on your device, making installs and upgrades faster and more reliable with fewer disk writes.
+- **Home Assistant now downloads a tested prebuilt image** instead of building the add-on on your device, making installs and upgrades faster and more reliable with fewer disk writes. If an existing install still builds locally, uninstall and reinstall the add-on once.
 
 ### Security
 

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.28.0] - 2026-08-22
+
+### Added
+
+- **The add-on now has its own Home Assistant icon and a first-run guide** covering installation, MQTT setup and the first ten minutes.
+
+### Fixed
+
+- **Lights now confirm switch and dim commands immediately** instead of waiting for the next C-Bus event.
+- **Removed trigger scenes and buttons are now cleaned up** instead of remaining unavailable in Home Assistant.
+- **Blank or space-padded MQTT, C-Gate and web credentials are handled consistently.**
+- **Invalid settings reloads are rejected without replacing the working configuration.**
+
+### Changed
+
+- **Home Assistant now downloads a tested prebuilt image** instead of building the add-on on your device, making installs and upgrades faster and more reliable with fewer disk writes.
+
+### Security
+
+- **Sensitive C-Gate, MQTT and alarm-keypad values are redacted from more error paths.**
+- **Label imports now enforce their size limits before parsing** and return safe errors for malformed archives and XML.
+
 ## [1.27.0] - 2026-08-21
 
 ### Added

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -3,14 +3,15 @@ version: "1.27.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"
+image: "ghcr.io/dougrathbone/cgateweb"
 # Supervisor warns that armhf/armv7/i386 are deprecated arch values (#44). They
 # are kept deliberately: the per-arch base images they build from are still
 # published, and dropping them would cut off updates for anyone on a 32-bit
 # Home Assistant install. Revisit when HA stops publishing those bases.
 #
-# This is also why build.yaml still exists. Its deprecation and this one are
-# coupled — folding the base image into the Dockerfile means one BUILD_FROM
-# default, and only the multi-arch index (amd64/arm64) can serve that role.
+# This is also why build.yaml remains for local and CI builds. Folding the base
+# image into the Dockerfile would mean one BUILD_FROM default, while the 32-bit
+# architectures still require their own Home Assistant base image.
 arch:
   - aarch64
   - amd64

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.27.0"
+version: "1.28.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.27.0",
+      "version": "1.28.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.27.0",
+  "version": "1.28.0",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Publishes tested multi-architecture add-on images to GHCR before advertising each release, so Home Assistant pulls the image instead of building it on the user's device. Bumps the release to v1.28.0 and records all user-facing changes since v1.27.0.

## Changes

- build and push amd64, aarch64, armv7, armhf, and i386 images on release tags
- publish one generic multi-architecture manifest, make the GHCR package public, and verify anonymous pulls before distribution
- gate the distribution repository update on successful image publication
- configure Supervisor to pull `ghcr.io/dougrathbone/cgateweb:<version>`
- bump package and add-on metadata to 1.28.0 with release notes

## Test plan

- [x] `npm test -- --runInBand` passes locally with no failures
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] add-on config and translation validators pass
- [x] actionlint passes
- [x] Existing tests were not broken or removed

## Checklist

- [x] Version bumped in `package.json` and `homeassistant-addon/config.yaml`
- [x] `CHANGELOG.md` updated
- [x] No sensitive data or credentials included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

