### PR TITLE
Verify anonymous GHCR access and release v1.28.1

### DIFF
--- a/.github/workflows/hacs-distribution.yml
+++ b/.github/workflows/hacs-distribution.yml
@@ -140,33 +140,43 @@ jobs:
           "ghcr.io/dougrathbone/cgateweb:${VERSION}-armhf" \
           "ghcr.io/dougrathbone/cgateweb:${VERSION}-i386"
 
-    # GHCR packages default to private on first publish. Supervisor pulls
-    # anonymously, so a private package would make the advertised version
-    # uninstallable. This is a no-op once the package is already public.
-    - name: Make the package public
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        if ! gh api --method POST \
-          "/user/packages/container/cgateweb/visibility" \
-          -f visibility=public; then
-          echo "::error::Could not make ghcr.io/dougrathbone/cgateweb public. Open Package settings and set visibility to Public, then re-run this workflow."
-          exit 1
-        fi
-
+    # Supervisor pulls without credentials, so a package that is not publicly
+    # readable makes the advertised version uninstallable. A package published
+    # from this workflow inherits the visibility of this public repository, so
+    # this verifies that rather than trying to change it -- GITHUB_TOKEN cannot
+    # set package visibility, and a step that tried returned 404 and failed the
+    # v1.28.0 release after the images had already published successfully.
+    #
+    # Queried over the registry API with no credentials at all: `docker
+    # buildx imagetools inspect` can pass on a private package by reusing the
+    # login above from a credential helper.
     - name: Verify users can pull the image anonymously
       env:
         VERSION: ${{ github.ref_name }}
+        EXPECTED_ARCH_COUNT: 5
       run: |
         VERSION=${VERSION#v}
-        docker logout ghcr.io
-        for i in 1 2 3 4 5; do
-          if docker buildx imagetools inspect "ghcr.io/dougrathbone/cgateweb:${VERSION}"; then
+        for attempt in 1 2 3 4 5; do
+          token=$(curl -fsSL \
+            "https://ghcr.io/token?scope=repository:dougrathbone/cgateweb:pull&service=ghcr.io" \
+            | jq -r '.token') || token=""
+          if [[ -n "$token" ]] && curl -fsSL \
+            -H "Authorization: Bearer ${token}" \
+            -H 'Accept: application/vnd.oci.image.index.v1+json' \
+            -o manifest.json \
+            "https://ghcr.io/v2/dougrathbone/cgateweb/manifests/${VERSION}"; then
+            count=$(jq '.manifests | length' manifest.json)
+            if [[ "$count" != "${EXPECTED_ARCH_COUNT}" ]]; then
+              echo "::error::ghcr.io/dougrathbone/cgateweb:${VERSION} lists ${count} architectures, expected ${EXPECTED_ARCH_COUNT}."
+              jq '[.manifests[].platform]' manifest.json
+              exit 1
+            fi
+            echo "Anonymous pull OK: ${VERSION} serves ${count} architectures."
             exit 0
           fi
-          sleep $((i * 5))
+          sleep $((attempt * 5))
         done
-        echo "::error::Anonymous inspect of ghcr.io/dougrathbone/cgateweb:${VERSION} failed. The package must be public."
+        echo "::error::Could not read ghcr.io/dougrathbone/cgateweb:${VERSION} anonymously. Check the package is Public in Package settings."
         exit 1
 
   build-and-deploy:

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.28.1] - 2026-08-22
+
+### Fixed
+
+- **The 1.28.0 release now actually ships.** A release step could not set the new image package's visibility and stopped the publish after the images had been built.
+
 ## [1.28.0] - 2026-08-22
 
 ### Added

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.28.0"
+version: "1.28.1"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.28.0",
+      "version": "1.28.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The v1.28.0 tag published all five architecture images and the multi-architecture manifest successfully, then failed on a step that tried to set the GHCR package visibility. `GITHUB_TOKEN` cannot do that, so the call returned 404 and the distribution publish never ran.

The step was also unnecessary: a package published from this workflow inherits this public repository's visibility. `ghcr.io/dougrathbone/cgateweb:1.28.0` is already anonymously readable and serves all five platforms, confirmed against the registry API with no credentials.

## Changes

- replace the visibility mutation with an anonymous registry-API verification
- assert the published manifest serves all five architectures before distributing
- query with no credentials, since `imagetools inspect` can pass on a private package by reusing the workflow login
- release v1.28.1

## Test plan

- [x] `npm test -- --runInBand` passes locally with no failures
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] add-on config and translation validators pass
- [x] actionlint passes
- [x] verification logic confirmed against the real published 1.28.0 manifest (200, five platforms, no credentials)

## Checklist

- [x] Version bumped in `package.json` and `homeassistant-addon/config.yaml`
- [x] `CHANGELOG.md` updated
- [x] No sensitive data or credentials included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

