### PR TITLE
Release v1.29.0

### DIFF
--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.29.0] - 2026-08-22
+
+### Added
+
+- **The C-Bus network clock can now be turned on in the add-on.** Date and time from the bus become two diagnostic sensors. Off by default; cgateweb never sets the clock. (#66)
+- **PIR and relay applications can now be chosen in the add-on.**
+- **Groups that appear on the bus but not in Toolkit can become Home Assistant entities.** Off by default; leftover discovery configs have to be cleaned off the broker by hand. (#63)
+- **Temperature Broadcast groups accept a Celsius write** between 0 and 63.75.
+- **Scene Module play and record work over MQTT.** Off by default because record overwrites module memory.
+- **Alarm zones now get C-Gate names, a loop-fault sensor, and password-entry codes 1 to 4.**
+
+### Fixed
+
+- **Clock ticks that arrive with a C-Gate status-channel prefix are now decoded.** (#66)
+
 ## [1.28.1] - 2026-08-22
 
 ### Fixed

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.28.1"
+version: "1.29.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.28.1",
+      "version": "1.29.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.28.1",
+  "version": "1.29.0",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",

--- a/tests/cgateWebBridge.test.js
+++ b/tests/cgateWebBridge.test.js
@@ -1189,6 +1189,18 @@ describe('CgateWebBridge', () => {
                 expect(bridge.haDiscovery.ensureTemperatureDiscovery).toHaveBeenCalledWith('254', '25', '3');
             });
 
+            it('asks HA discovery about an unlisted lighting group on a live event', () => {
+                bridge.haDiscovery = {
+                    ensureTemperatureDiscovery: jest.fn(),
+                    ensureUnlistedGroupDiscovery: jest.fn()
+                };
+
+                bridge._processEventLine('lighting on 254/56/251');
+
+                expect(bridge.haDiscovery.ensureUnlistedGroupDiscovery)
+                    .toHaveBeenCalledWith('254', '56', '251');
+            });
+
             it('should log a warning for unknown mode codes and still consume the line', () => {
                 const warnSpy = jest.spyOn(bridge.logger, 'warn');
                 const publishSpy = jest.spyOn(bridge.mqttManager, 'publish');

--- a/tests/commandResponseProcessor.test.js
+++ b/tests/commandResponseProcessor.test.js
@@ -513,6 +513,17 @@ describe('CommandResponseProcessor', () => {
             expect(mockOnObjectStatus).toHaveBeenCalledWith(expect.any(CBusEvent));
         });
 
+        it('asks HA discovery about an unlisted lighting group on a command-port status', () => {
+            mockHaDiscovery.ensureUnlistedGroupDiscovery = jest.fn();
+            processor._processCommandObjectStatus('//SHAC/254/56/251: level=255');
+            expect(mockHaDiscovery.ensureUnlistedGroupDiscovery).toHaveBeenCalledWith('254', '56', '251');
+        });
+
+        it('does not throw when unlisted-group discovery is not on the HA discovery object', () => {
+            expect(() => processor._processCommandObjectStatus('//SHAC/254/56/1: level=255')).not.toThrow();
+            expect(mockEventPublisher.publishEvent).toHaveBeenCalled();
+        });
+
         it('should warn about invalid object status data', () => {
             const statusData = 'invalid status data';
             

--- a/tests/mqttCommandRouter.test.js
+++ b/tests/mqttCommandRouter.test.js
@@ -1358,8 +1358,11 @@ describe('MqttCommandRouter', () => {
         });
 
         it('rejects a temperature outside 0–63.75 °C', () => {
+            const warnSpy = jest.spyOn(router.logger, 'warn');
             router.routeMessage('cbus/write/254/25/3/temperature', '80');
             expect(mockQueue.add).not.toHaveBeenCalled();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid temperature'));
+            warnSpy.mockRestore();
         });
 
         it('rejects a temperature command on a non-broadcast application', () => {
@@ -1370,8 +1373,11 @@ describe('MqttCommandRouter', () => {
 
     describe('scene module play/record', () => {
         it('ignores play when the feature is off', () => {
+            const warnSpy = jest.spyOn(router.logger, 'warn');
             router.routeMessage('cbus/write/254/203/1/play', '4');
             expect(mockQueue.add).not.toHaveBeenCalled();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('cbus_scene_module_enabled is off'));
+            warnSpy.mockRestore();
         });
 
         it('sends scene play and record when enabled', () => {
@@ -1381,6 +1387,18 @@ describe('MqttCommandRouter', () => {
             mockQueue.add.mockClear();
             router.routeMessage('cbus/write/254/203/1/record', '4');
             expect(mockQueue.add).toHaveBeenCalledWith('scene record 1 4\n');
+        });
+
+        it('rejects a scene number outside 0–255', () => {
+            router.settings.cbus_scene_module_enabled = true;
+            const warnSpy = jest.spyOn(router.logger, 'warn');
+            for (const payload of ['256', '-1', 'nope']) {
+                mockQueue.add.mockClear();
+                router.routeMessage('cbus/write/254/203/1/play', payload);
+                expect(mockQueue.add).not.toHaveBeenCalled();
+            }
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid Scene Module scene'));
+            warnSpy.mockRestore();
         });
     });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release 1.29.0 so Home Assistant picks up the C-Bus feature work already on master: clock switch, PIR/relay options, unlisted groups, temperature inject, Scene Module, security zone leftovers, and the #s# clock decode (#66, #63).

Also adds the two tests called out after merge: unlisted-group discovery through the event and command paths, and Scene Module rejects for an invalid scene number.

## Changes

- Tests for unlisted-group wiring and Scene Module validation
- Version 1.29.0 in package.json and the add-on config
- Changelog for 1.29.0

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification

## Checklist

- [x] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [x] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fac29f8-ed7b-4129-a5c6-1fedd506a6f2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

