### PR TITLE
fix(addon): cap managed C-Gate log growth on persistent storage

### DIFF
--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -83,6 +83,30 @@ to a different C-Gate version:
 Both paths preserve your project databases (`Projects/`) and C-Gate config
 across the reinstall.
 
+#### Managed C-Gate disk usage
+
+C-Gate stores its program, project databases, configuration, and log files on
+the add-on's persistent `/data/cgate` volume. On a busy network C-Gate can
+write large amounts to `logs/` and to rotated `event.*.log` segments, which was
+the cause of multi-gigabyte growth reported in [issue #81](https://github.com/dougrathbone/cgateweb/issues/81).
+
+On every start the add-on:
+
+- enables C-Gate's built-in event-file rotation (`event-file.split=yes`, 5 MiB
+  per segment, 50 segments retained)
+- prunes files under `logs/` (and legacy `log/`) older than 7 days
+- if log files still exceed 500 MiB total, deletes the oldest segments until
+  under that cap
+
+Your project databases and `config/` are never touched. The active `event.log`
+is kept; only older rotated segments are eligible for pruning.
+
+**If you already have tens of gigabytes of old logs**, restart the add-on once
+to let startup pruning reclaim space, or delete the contents of `/data/cgate/logs/`
+manually via the Samba/SSH/File Editor add-ons. A `cgate_force_reinstall` also
+wipes log directories (while preserving `Projects/` and `config/`), but a normal
+restart is enough now that pruning runs each boot.
+
 #### Loading your C-Gate project in managed mode
 
 Installing C-Gate (above) gives you a running C-Gate process but does **not**

--- a/homeassistant-addon/rootfs/etc/cont-init.d/cgate-install.sh
+++ b/homeassistant-addon/rootfs/etc/cont-init.d/cgate-install.sh
@@ -24,6 +24,14 @@ CGATEWEB_DEFAULT_DOWNLOAD_URL="https://download.se.com/files?p_Doc_Ref=C-Gate_3_
 # the supported answer for users, and this constant is the fix for everyone else.
 CGATEWEB_DEFAULT_DOWNLOAD_SHA256="1d871bcd38355234a3b5b30a208463c8be079aa9346152476f2209f516cf271d"
 
+# Managed C-Gate log retention (#81). C-Gate writes unbounded files under
+# /data/cgate/logs/ and rotated event-file segments; without a cap a busy
+# network can fill the host SD card. Pruned on every boot before C-Gate starts.
+CGATEWEB_LOG_MAX_BYTES="${CGATEWEB_LOG_MAX_BYTES:-524288000}"   # 500 MiB
+CGATEWEB_LOG_MAX_AGE_DAYS="${CGATEWEB_LOG_MAX_AGE_DAYS:-7}"
+CGATEWEB_EVENT_FILE_SPLIT_SIZE="${CGATEWEB_EVENT_FILE_SPLIT_SIZE:-5000000}"  # 5 MiB (C-Gate default)
+CGATEWEB_EVENT_FILE_SPLIT_COUNT="${CGATEWEB_EVENT_FILE_SPLIT_COUNT:-50}"   # ~250 MiB of event segments
+
 # The identity-aware serial resolver (issue #28) and the file it publishes its
 # answer to. Both are overridable so the unit tests can run the repo copy of
 # the resolver and keep its bookkeeping out of /run.
@@ -241,6 +249,105 @@ _cgateweb_apply_cgate_config() {
     _cgateweb_set_config_key "${config_file}" "project.default" "${project}"
     _cgateweb_set_config_key "${config_file}" "project.start" "${project}"
     _cgateweb_set_config_key "${config_file}" "command-port" "${command_port}"
+
+    # Cap C-Gate's on-disk event log when use-event-file is enabled. C-Gate
+    # rotates at split-size and keeps split-count segments; without this a
+    # single event.log can grow without bound (#81).
+    _cgateweb_set_config_key "${config_file}" "event-file.split" "yes"
+    _cgateweb_set_config_key "${config_file}" "event-file.split-size" "${CGATEWEB_EVENT_FILE_SPLIT_SIZE}"
+    _cgateweb_set_config_key "${config_file}" "event-file.split-count" "${CGATEWEB_EVENT_FILE_SPLIT_COUNT}"
+}
+
+# Return 0 when a file under the managed C-Gate install may be pruned.
+# Only log directories and rotated event-file segments are eligible — never
+# Projects/, config/, or the live event.log C-Gate is writing.
+_cgateweb_prune_cgate_logs_is_prunable() {
+    local cgate_dir="$1" file="$2"
+    case "${file}" in
+        "${cgate_dir}/logs"/*|"${cgate_dir}/log"/*) return 0 ;;
+        "${cgate_dir}/event."*.log)
+            # event.log is the active segment; event.N.log are rotated.
+            [[ "${file}" == "${cgate_dir}/event.log" ]] && return 1
+            return 0
+            ;;
+        "${cgate_dir}/event-"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Prune C-Gate log files under the managed install directory. Runs on every
+# boot before C-Gate starts so a reinstall is not the only way to reclaim
+# space (#81). Echoes a one-line summary when anything was removed.
+_cgateweb_prune_cgate_logs() {
+    local cgate_dir="$1"
+    local max_bytes="${2:-${CGATEWEB_LOG_MAX_BYTES}}"
+    local max_age_days="${3:-${CGATEWEB_LOG_MAX_AGE_DAYS}}"
+    local -a candidates=()
+    local file age_bytes deleted_age=0 deleted_size=0 reclaimed=0
+
+    [[ -d "${cgate_dir}" ]] || return 0
+
+    while IFS= read -r -d '' file; do
+        _cgateweb_prune_cgate_logs_is_prunable "${cgate_dir}" "${file}" || continue
+        candidates+=("${file}")
+    done < <(find "${cgate_dir}" \( -path "${cgate_dir}/logs/*" -o -path "${cgate_dir}/log/*" \
+        -o -name 'event.*.log' -o -name 'event-*' \) -type f -print0 2>/dev/null)
+
+    if [[ ${#candidates[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    for file in "${candidates[@]}"; do
+        [[ -f "${file}" ]] || continue
+        if find "${file}" -mtime +"${max_age_days}" -print -quit 2>/dev/null | grep -q .; then
+            age_bytes=$(stat -c '%s' "${file}" 2>/dev/null || echo 0)
+            rm -f "${file}" && deleted_age=$((deleted_age + 1)) && reclaimed=$((reclaimed + age_bytes))
+        fi
+    done
+
+    # Rebuild the candidate list after age pruning.
+    candidates=()
+    while IFS= read -r -d '' file; do
+        _cgateweb_prune_cgate_logs_is_prunable "${cgate_dir}" "${file}" || continue
+        candidates+=("${file}")
+    done < <(find "${cgate_dir}" \( -path "${cgate_dir}/logs/*" -o -path "${cgate_dir}/log/*" \
+        -o -name 'event.*.log' -o -name 'event-*' \) -type f -print0 2>/dev/null)
+
+    local total=0 size
+    for file in "${candidates[@]}"; do
+        [[ -f "${file}" ]] || continue
+        size=$(stat -c '%s' "${file}" 2>/dev/null || echo 0)
+        total=$((total + size))
+    done
+
+    while [[ ${total} -gt ${max_bytes} && ${#candidates[@]} -gt 0 ]]; do
+        local oldest="" oldest_mtime=9999999999 oldest_size=0 idx=-1 i mtime
+        for i in "${!candidates[@]}"; do
+            file="${candidates[$i]}"
+            [[ -f "${file}" ]] || continue
+            mtime=$(stat -c '%Y' "${file}" 2>/dev/null || echo 0)
+            if [[ ${mtime} -lt ${oldest_mtime} ]]; then
+                oldest_mtime=${mtime}
+                oldest="${file}"
+                oldest_size=$(stat -c '%s' "${file}" 2>/dev/null || echo 0)
+                idx=${i}
+            fi
+        done
+        [[ -n "${oldest}" && ${idx} -ge 0 ]] || break
+        rm -f "${oldest}" && deleted_size=$((deleted_size + 1)) && reclaimed=$((reclaimed + oldest_size)) \
+            && total=$((total - oldest_size))
+        unset "candidates[${idx}]"
+        # Compact sparse array after unset.
+        local compact=()
+        for file in "${candidates[@]}"; do
+            [[ -n "${file}" ]] && compact+=("${file}")
+        done
+        candidates=("${compact[@]}")
+    done
+
+    if [[ $((deleted_age + deleted_size)) -gt 0 ]]; then
+        bashio::log.info "Pruned C-Gate log files: ${deleted_age} older than ${max_age_days} day(s), ${deleted_size} over the ${max_bytes}-byte cap (~$((reclaimed / 1048576)) MiB reclaimed)"
+    fi
 }
 
 # Whether the user explicitly asked to reinstall/upgrade C-Gate via the
@@ -1138,5 +1245,7 @@ _cgateweb_apply_cgate_config "${CGATE_CONFIG}" "${CGATE_PROJECT}" "${CGATE_PORT}
 bashio::log.info "Set project to: ${CGATE_PROJECT} (project.default + project.start)"
 bashio::log.info "Set command port to: ${CGATE_PORT}"
 bashio::log.info "Left event-port at C-Gate default (status stream stays on 20025 for cgateweb)"
+bashio::log.info "Capped C-Gate event-file logs at ${CGATEWEB_EVENT_FILE_SPLIT_COUNT} x ${CGATEWEB_EVENT_FILE_SPLIT_SIZE} bytes"
+_cgateweb_prune_cgate_logs "${CGATE_DIR}"
 
 bashio::log.info "C-Gate installation complete"

--- a/tests/cgateInstallScript.test.js
+++ b/tests/cgateInstallScript.test.js
@@ -483,6 +483,129 @@ describeBash('cgate-install.sh helpers', () => {
             expect(twice.match(/^project\.start=/gm)).toHaveLength(1);
             expect(twice.match(/^project\.default=/gm)).toHaveLength(1);
         });
+
+        test('enables rotated C-Gate event-file logging with bounded retention (#81)', () => {
+            const out = applyCgateConfig({
+                initialConfig: BASE_CONFIG, project: 'HOME', commandPort: 20023, eventPort: 20025
+            });
+            expect(out).toMatch(/^event-file\.split=yes$/m);
+            expect(out).toMatch(/^event-file\.split-size=5000000$/m);
+            expect(out).toMatch(/^event-file\.split-count=50$/m);
+        });
+    });
+
+    describe('_cgateweb_prune_cgate_logs', () => {
+        function runPruneLogs({ files, maxBytes = 1000, maxAgeDays = 7, now = Date.now() }) {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgate-prune-'));
+            const cgateDir = path.join(dir, 'cgate');
+            fs.mkdirSync(path.join(cgateDir, 'logs'), { recursive: true });
+            for (const spec of files) {
+                const rel = spec.path || spec;
+                const full = path.join(cgateDir, rel);
+                fs.mkdirSync(path.dirname(full), { recursive: true });
+                const content = 'x'.repeat(spec.size || 1);
+                fs.writeFileSync(full, content);
+                const ageDays = spec.ageDays ?? 0;
+                const mtime = new Date(now - ageDays * 24 * 60 * 60 * 1000);
+                fs.utimesSync(full, mtime, mtime);
+            }
+            const env = {
+                ...process.env,
+                CGATEWEB_INSTALL_SOURCE_ONLY: '1',
+                CGW_INSTALL_SCRIPT: SCRIPT,
+                CGATEWEB_SERIAL_DEVICE_LIB: SERIAL_DEVICE_LIB,
+                CGW_ARG_0: cgateDir,
+                CGW_ARG_1: String(maxBytes),
+                CGW_ARG_2: String(maxAgeDays)
+            };
+            const script = `
+                set -u
+                ${BASHIO_STUB_WITH_LOGS}
+                source "$CGW_INSTALL_SCRIPT"
+                _cgateweb_prune_cgate_logs "$CGW_ARG_0" "$CGW_ARG_1" "$CGW_ARG_2"
+            `;
+            const output = execFileSync('bash', ['-c', script], { encoding: 'utf8', env });
+            const remaining = [];
+            const walk = (base) => {
+                if (!fs.existsSync(base)) return;
+                for (const entry of fs.readdirSync(base, { withFileTypes: true })) {
+                    const full = path.join(base, entry.name);
+                    if (entry.isDirectory()) walk(full);
+                    else remaining.push(path.relative(cgateDir, full));
+                }
+            };
+            walk(cgateDir);
+            fs.rmSync(dir, { recursive: true, force: true });
+            return { output, remaining };
+        }
+
+        test('removes log files older than the age limit', () => {
+            const r = runPruneLogs({
+                files: [
+                    { path: 'logs/old.log', ageDays: 10, size: 100 },
+                    { path: 'logs/recent.log', ageDays: 1, size: 100 }
+                ],
+                maxBytes: 100000,
+                maxAgeDays: 7
+            });
+            expect(r.remaining).toEqual(['logs/recent.log']);
+            expect(r.output).toMatch(/Pruned C-Gate log files/);
+        });
+
+        test('removes oldest files when total size exceeds the cap', () => {
+            const r = runPruneLogs({
+                files: [
+                    { path: 'logs/a.log', ageDays: 3, size: 300 },
+                    { path: 'logs/b.log', ageDays: 2, size: 300 },
+                    { path: 'logs/c.log', ageDays: 1, size: 300 }
+                ],
+                maxBytes: 700,
+                maxAgeDays: 30
+            });
+            expect(r.remaining.sort()).toEqual(['logs/b.log', 'logs/c.log']);
+        });
+
+        test('prunes rotated event-file segments but keeps the active event.log', () => {
+            const r = runPruneLogs({
+                files: [
+                    { path: 'event.log', ageDays: 30, size: 400 },
+                    { path: 'event.11.log', ageDays: 30, size: 400 }
+                ],
+                maxBytes: 100,
+                maxAgeDays: 30
+            });
+            expect(r.remaining).toEqual(['event.log']);
+        });
+
+        test('does not touch project databases or config', () => {
+            const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cgate-prune-safe-'));
+            const cgateDir = path.join(dir, 'cgate');
+            fs.mkdirSync(path.join(cgateDir, 'Projects', 'HOME'), { recursive: true });
+            fs.mkdirSync(path.join(cgateDir, 'config'), { recursive: true });
+            fs.writeFileSync(path.join(cgateDir, 'Projects', 'HOME', 'HOME.db'), 'db');
+            fs.writeFileSync(path.join(cgateDir, 'config', 'C-GateConfig.txt'), 'x');
+            fs.mkdirSync(path.join(cgateDir, 'logs'), { recursive: true });
+            fs.writeFileSync(path.join(cgateDir, 'logs', 'big.log'), 'x'.repeat(5000));
+            const env = {
+                ...process.env,
+                CGATEWEB_INSTALL_SOURCE_ONLY: '1',
+                CGW_INSTALL_SCRIPT: SCRIPT,
+                CGATEWEB_SERIAL_DEVICE_LIB: SERIAL_DEVICE_LIB,
+                CGW_ARG_0: cgateDir,
+                CGW_ARG_1: '100',
+                CGW_ARG_2: '7'
+            };
+            const script = `
+                set -u
+                ${BASHIO_STUB_WITH_LOGS}
+                source "$CGW_INSTALL_SCRIPT"
+                _cgateweb_prune_cgate_logs "$CGW_ARG_0" "$CGW_ARG_1" "$CGW_ARG_2"
+            `;
+            execFileSync('bash', ['-c', script], { encoding: 'utf8', env });
+            expect(fs.existsSync(path.join(cgateDir, 'Projects', 'HOME', 'HOME.db'))).toBe(true);
+            expect(fs.existsSync(path.join(cgateDir, 'config', 'C-GateConfig.txt'))).toBe(true);
+            fs.rmSync(dir, { recursive: true, force: true });
+        });
     });
 
     describe('_cgateweb_check_serial_device (USB-serial PCI, #28)', () => {


### PR DESCRIPTION
## Summary

Fixes #81. Managed C-Gate was writing unbounded log files under `/data/cgate`, which could fill a Home Assistant host SD card (44+ GB reported).

## Changes

- Enable C-Gate event-file rotation in `C-GateConfig.txt` (5 MiB segments, 50 retained)
- Prune `logs/` / `log/` and rotated `event.*.log` files on every add-on start: drop files older than 7 days, then delete oldest segments until total log size is under 500 MiB
- Document one-time cleanup for installs that already have large log directories
- Unit tests for config keys and pruning behaviour

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification

## Checklist

- [ ] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [ ] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included