### PR TITLE
chore: release v1.30.0

### DIFF
--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.30.0] - 2026-08-23
+
+### Fixed
+
+- **Managed C-Gate logs are now rotated and pruned** so they cannot fill the host disk. (#81) Restart the add-on once if an install already filled the disk.
+
+### Changed
+
+- **The add-on icon and logo are restored** to the earlier blue house-bridge artwork.
+- Internal: sql.js updated to 1.14.2.
+
 ## [1.29.0] - 2026-08-22
 
 ### Added

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.29.0"
+version: "1.30.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",


### PR DESCRIPTION
## Summary

Minor release **v1.30.0** after merging the managed C-Gate log cap (#82 / #81), the add-on icon/logo restore (#84), and the sql.js 1.14.2 bump (#79).

## Changes

- Bump `package.json` and `homeassistant-addon/config.yaml` to 1.30.0 (kept in sync)
- CHANGELOG for 1.30.0: log rotation/pruning, restored artwork, sql.js internal note

## Test plan

- [x] `npm test` passes locally with no failures
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run validate:addon-config` / `validate:translations` pass
- [x] Existing tests were not broken or removed without justification

## Checklist

- [x] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [x] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

After merge: tag `v1.30.0` and push to trigger hacs-distribution; backfill source-repo GitHub Release.