### PR TITLE
fix: refresh clock sensors on Home Assistant restart

### DIFF
--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.30.1] - 2026-08-24
+
+### Fixed
+
+- **Clock date and time sensors now refresh when Home Assistant restarts**, the same way lighting and security already do. (#66)
+- **A clock refresh echo from C-Gate is no longer logged as an unparsed event.** (#66)
+
 ## [1.30.0] - 2026-08-23
 
 ### Fixed

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.30.0"
+version: "1.30.1"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.29.0",
+  "version": "1.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.29.0",
+      "version": "1.30.1",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",

--- a/src/applicationDecoders/clockDecoder.js
+++ b/src/applicationDecoders/clockDecoder.js
@@ -40,16 +40,15 @@ const { normalizeAppEventLine, isAppEventLine } = require('./appEventLine');
  *   - the meaning of that trailing field (docs/cgate-manual.md documents only
  *     the command names `CLOCK DATE|TIME|REQUEST_REFRESH`, never an
  *     event-port grammar).
- *   - any sub-verb other than `date` and `time`. C-Gate has a
- *     `REQUEST_REFRESH` command, so a corresponding broadcast may well exist,
- *     but no capture of one exists here — it decodes to null rather than to an
- *     invented shape.
+ *   - any sub-verb other than `date` and `time` as a published reading. A
+ *     `clock request_refresh` echo is now captured (#66) and recognised so
+ *     callers can consume it without logging it as unparsed; it is not a
+ *     date or time broadcast, so decodeLine still returns null.
  *
  * Everything not proven above returns null (fail closed). A wrong guess in a
  * decoder is worse than a missing feature: it publishes confident nonsense.
  * Unrecognised clock traffic still reaches raw event capture
- * (`cbusRawEventLogApps`), which is how a real `request_refresh` or
- * variant-format capture can be obtained to extend this decoder later.
+ * (`cbusRawEventLogApps`).
  */
 
 // C-Bus Clock and Timekeeping is fixed at $DF / 223 by the application spec —
@@ -80,6 +79,26 @@ const TIME_REGEX = /^(\d{2}):(\d{2}):(\d{2})$/;
 function isClockLine(line) {
     if (typeof line !== 'string' || line.length === 0) return false;
     return isAppEventLine(line, PREFIX);
+}
+
+/**
+ * Whether a clock line is a REQUEST_REFRESH command echo, not a date/time
+ * broadcast. Captured on a live site (#66):
+ *
+ *   clock request_refresh //MIDSTRM/254/223  #sourceunit=0 OID=
+ *
+ * sourceunit=0 is the bridge's own command coming back on the event port.
+ * Callers consume these silently; they are not readings.
+ *
+ * @param {string} line - Raw line from the C-Gate event stream.
+ * @returns {boolean}
+ */
+function isClockRequestRefreshLine(line) {
+    if (typeof line !== 'string') return false;
+    const normalized = normalizeAppEventLine(line, PREFIX);
+    if (!normalized) return false;
+    const parts = normalized.text.split(/\s+/).filter(Boolean);
+    return parts.length >= 2 && parts[1] === 'request_refresh';
 }
 
 /**
@@ -181,4 +200,4 @@ function decodeValue() {
     return null;
 }
 
-module.exports = { appId, isClockLine, decodeLine, decodeValue };
+module.exports = { appId, isClockLine, isClockRequestRefreshLine, decodeLine, decodeValue };

--- a/src/bridgeInitializationService.js
+++ b/src/bridgeInitializationService.js
@@ -536,7 +536,7 @@ class BridgeInitializationService {
      * Ask the network clock to rebroadcast date and time after connect.
      * Read-only: this never sets the C-Bus clock.
      */
-    sendClockRefreshRequests() {
+    sendClockRefreshRequests(options = {}) {
         if (!this.settings.cbus_clock_enabled) return;
         const networks = this._resolveMonitorNetworkIds();
         if (networks.length === 0) return;
@@ -545,7 +545,8 @@ class BridgeInitializationService {
                 buildClockRequestRefresh({
                     cbusname: this.settings.cbusname,
                     network
-                }) + NEWLINE
+                }) + NEWLINE,
+                options
             );
         }
         this.logger.info(`Requested C-Bus clock refresh for networks: ${networks.join(', ')}`);

--- a/src/cgateWebBridge.js
+++ b/src/cgateWebBridge.js
@@ -725,6 +725,10 @@ class CgateWebBridge {
     _handleClockLine(line) {
         if (!clockDecoder.isClockLine(line)) return false;
 
+        // Own CLOCK REQUEST_REFRESH echo (sourceunit=0). Not a reading; consume
+        // it so it does not log as an unparsed clock line (#66).
+        if (clockDecoder.isClockRequestRefreshLine(line)) return true;
+
         if (!this.settings.cbus_clock_enabled) return LINE_UNPARSED;
 
         const reading = clockDecoder.decodeLine(line);
@@ -804,8 +808,8 @@ class CgateWebBridge {
         // Reached when the feature is off, or on but the line was a shape the
         // decoder refuses to guess at. Either way it has now passed through
         // _publishRawEventCapture above, so `cbusRawEventLogApps` can capture
-        // real app-223 traffic — which is how the format gets confirmed, or a
-        // `request_refresh` broadcast obtained, without decoding it blind.
+        // real app-223 traffic without decoding it blind. Known
+        // `request_refresh` echoes are consumed in _handleClockLine instead.
         if (clockState === LINE_UNPARSED) {
             this.logger.debug(`Unparsed clock line (captured, not a standard event): ${redactCgateLine(line)}`);
             return;

--- a/src/stateResyncCoordinator.js
+++ b/src/stateResyncCoordinator.js
@@ -36,7 +36,7 @@ class StateResyncCoordinator {
      * @param {Object} deps.settings
      * @param {ReturnType<typeof import('./logger').createLogger>} deps.logger
      * @param {() => (Object|null)} deps.getHaDiscovery - late-bound: haDiscovery is built after the bridge constructor
-     * @param {() => ({ sendGetallLevels: Function, sendSecurityStatusRequests: Function }|null)} deps.getInitializationService
+     * @param {() => ({ sendGetallLevels: Function, sendSecurityStatusRequests: Function, sendClockRefreshRequests: Function }|null)} deps.getInitializationService
      *   late-bound: the coordinator is built in _buildSubsystems, which runs
      *   before the bridge assigns its initializationService. Taking the service
      *   by value there captured undefined and threw on every resync (issue #44).
@@ -137,6 +137,11 @@ class StateResyncCoordinator {
         // security app is deliberately absent from those, so an install with
         // ha_discovery_networks set but no getall_networks still resyncs zones.
         initializationService.sendSecurityStatusRequests('resync');
+
+        // Clock sensors are not covered by lighting getall. Without a refresh,
+        // they go unknown on a Home Assistant restart until the next bus tick
+        // (often hours). Same path as lighting and security (#66).
+        initializationService.sendClockRefreshRequests({ priority: 'bulk' });
 
         if (netapps.length === 0) {
             this.logger.debug(

--- a/tests/applicationDecoders/clockDecoder.test.js
+++ b/tests/applicationDecoders/clockDecoder.test.js
@@ -1,5 +1,5 @@
 const decoder = require('../../src/applicationDecoders/clockDecoder');
-const { isClockLine, decodeLine, decodeValue } = decoder;
+const { isClockLine, isClockRequestRefreshLine, decodeLine, decodeValue } = decoder;
 
 // Ground-truth fixtures: the only captured app-223 event-port lines that exist
 // anywhere in this repo, committed in 833b60e ("filter out C-Gate
@@ -32,6 +32,18 @@ describe('clockDecoder — isClockLine', () => {
         // decoder refuses to interpret it.
         expect(isClockLine('clock request_refresh //CLIPSAL/254/223 0')).toBe(true);
         expect(decodeLine('clock request_refresh //CLIPSAL/254/223 0')).toBeNull();
+    });
+
+    it('recognises a request_refresh echo as a known non-reading (#66)', () => {
+        const liveEcho = 'clock request_refresh //MIDSTRM/254/223  #sourceunit=0 OID= sessionId=cmd5 commandId={none}';
+        expect(isClockRequestRefreshLine(liveEcho)).toBe(true);
+        expect(isClockRequestRefreshLine('clock request_refresh //CLIPSAL/254/223 0')).toBe(true);
+        expect(isClockRequestRefreshLine('#s# clock request_refresh //MIDSTRM/254/223')).toBe(true);
+        expect(decodeLine(liveEcho)).toBeNull();
+        expect(isClockRequestRefreshLine(REAL_DATE_LINE)).toBe(false);
+        expect(isClockRequestRefreshLine('lighting on 254/56/4')).toBe(false);
+        expect(isClockRequestRefreshLine('')).toBe(false);
+        expect(isClockRequestRefreshLine(null)).toBe(false);
     });
 
     it('recognises a comment-prefixed clock line', () => {

--- a/tests/bridgeInitializationService.test.js
+++ b/tests/bridgeInitializationService.test.js
@@ -197,8 +197,8 @@ describe('BridgeInitializationService', () => {
             const svc = makeService(bridge);
             svc.sendClockRefreshRequests();
             expect(commandQueueAdd).toHaveBeenCalledTimes(2);
-            expect(commandQueueAdd).toHaveBeenCalledWith('clock request_refresh //HOME/254/223\n');
-            expect(commandQueueAdd).toHaveBeenCalledWith('clock request_refresh //HOME/1/223\n');
+            expect(commandQueueAdd).toHaveBeenCalledWith('clock request_refresh //HOME/254/223\n', {});
+            expect(commandQueueAdd).toHaveBeenCalledWith('clock request_refresh //HOME/1/223\n', {});
         });
 
         it('does nothing when the clock feature is off', () => {
@@ -209,6 +209,19 @@ describe('BridgeInitializationService', () => {
             const svc = makeService(bridge);
             svc.sendClockRefreshRequests();
             expect(commandQueueAdd).not.toHaveBeenCalled();
+        });
+
+        it('forwards command-queue options so a resync can use bulk priority', () => {
+            const { bridge, commandQueueAdd } = makeBridge({
+                cbus_clock_enabled: true,
+                ha_discovery_networks: [254]
+            });
+            const svc = makeService(bridge);
+            svc.sendClockRefreshRequests({ priority: 'bulk' });
+            expect(commandQueueAdd).toHaveBeenCalledWith(
+                'clock request_refresh //HOME/254/223\n',
+                { priority: 'bulk' }
+            );
         });
     });
 

--- a/tests/cgateWebBridge.test.js
+++ b/tests/cgateWebBridge.test.js
@@ -1663,12 +1663,15 @@ describe('CgateWebBridge', () => {
             const getall = jest.spyOn(bridge.initializationService, 'sendGetallLevels').mockReturnValue([]);
             const security = jest.spyOn(bridge.initializationService, 'sendSecurityStatusRequests')
                 .mockImplementation(() => {});
+            const clock = jest.spyOn(bridge.initializationService, 'sendClockRefreshRequests')
+                .mockImplementation(() => {});
 
             bridge.stateResyncCoordinator.requestResync('network-sync');
             expect(() => jest.runOnlyPendingTimers()).not.toThrow();
 
             expect(getall).toHaveBeenCalledWith(null, { priority: 'bulk' });
             expect(security).toHaveBeenCalledWith('resync');
+            expect(clock).toHaveBeenCalledWith({ priority: 'bulk' });
         });
     });
 
@@ -1818,10 +1821,20 @@ describe('CgateWebBridge', () => {
             it('publishes nothing for clock traffic the decoder will not guess at', () => {
                 const b = makeBridge({ cbus_clock_enabled: true });
                 mockConsoleWarn.mockClear();
-                b._processEventLine('clock request_refresh //CLIPSAL/254/223 0 #sourceunit=8 OID=');
+                b._processEventLine('clock sync //CLIPSAL/254/223 2026-03-02 0');
                 expect(b.eventPublisher.publishReading).not.toHaveBeenCalled();
                 expect(b.eventPublisher.publishEvent).not.toHaveBeenCalled();
                 expect(mockConsoleWarn).not.toHaveBeenCalled();
+            });
+
+            it('consumes a request_refresh echo without logging it as unparsed (#66)', () => {
+                const b = makeBridge({ cbus_clock_enabled: true });
+                const debug = jest.spyOn(b.logger, 'debug').mockImplementation(() => {});
+                b._processEventLine('clock request_refresh //MIDSTRM/254/223  #sourceunit=0 OID= sessionId=cmd5 commandId={none}');
+                expect(b.eventPublisher.publishReading).not.toHaveBeenCalled();
+                expect(b.eventPublisher.publishEvent).not.toHaveBeenCalled();
+                expect(debug.mock.calls.map(c => String(c[0])).join('\n')).not.toMatch(/Unparsed clock line/);
+                debug.mockRestore();
             });
 
             it('publishes nothing for a malformed clock line rather than throwing', () => {

--- a/tests/stateResyncCoordinator.test.js
+++ b/tests/stateResyncCoordinator.test.js
@@ -27,7 +27,8 @@ describe('StateResyncCoordinator', () => {
                 for (const netapp of pairs) commandQueue.add(`GET //TEST/${netapp}/* level\n`, options);
                 return pairs;
             }),
-            sendSecurityStatusRequests: jest.fn()
+            sendSecurityStatusRequests: jest.fn(),
+            sendClockRefreshRequests: jest.fn()
         };
         logger = { debug: jest.fn(), info: jest.fn(), warn: jest.fn() };
         coordinator = new StateResyncCoordinator({
@@ -125,6 +126,21 @@ describe('StateResyncCoordinator', () => {
             coordinator.requestResync('ha-birth');
             jest.advanceTimersByTime(5000);
             expect(initializationService.sendSecurityStatusRequests).toHaveBeenCalledWith('resync');
+        });
+    });
+
+    describe('clock sensors', () => {
+        it('asks the network clock to rebroadcast on the same resync as lighting and security', () => {
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(initializationService.sendClockRefreshRequests).toHaveBeenCalledWith({ priority: 'bulk' });
+        });
+
+        it('still refreshes the clock when no getall networks are configured', () => {
+            initializationService.sendGetallLevels = jest.fn().mockReturnValue([]);
+            coordinator.requestResync('ha-birth');
+            jest.advanceTimersByTime(5000);
+            expect(initializationService.sendClockRefreshRequests).toHaveBeenCalledWith({ priority: 'bulk' });
         });
     });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the follow-up on #66: after a Home Assistant restart, C-Bus clock date/time sensors went unknown even though lighting and security resynced, and C-Gate’s `clock request_refresh` echo was logged as an unparsed clock line.

## Changes

- Ask C-Gate for a clock refresh on the same HA-restart / MQTT-reconnect resync path as lighting getall and security status.
- Consume `clock request_refresh` event-port echoes (the captured `sourceunit=0` line) so they are not logged as unparsed.
- Patch release **1.30.1**.

Closes the remaining #66 follow-up from https://github.com/dougrathbone/cgateweb/issues/66#issuecomment-5390177727.

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New unit coverage for request_refresh recognition, silent consume, and resync calling clock refresh
- [x] Existing tests were not broken or removed without justification

## Checklist

- [x] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [x] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-421150b2-55d5-422c-a09a-31126093678d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-421150b2-55d5-422c-a09a-31126093678d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

