### PR TITLE
feat: list bypassed alarm zones and resend panel diagnostics on HA restart

### DIFF
--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.31.0] - 2026-08-25
+
+### Added
+
+- **Bypassed alarm zones are listed on the security panel** as a diagnostic sensor you can put on a dashboard next to the alarm card. (#62)
+
+### Fixed
+
+- **Alarm panel diagnostics no longer sit unknown after a Home Assistant restart.** Mains, battery and the other panel sensors are resent with lighting and the clock. (#62)
+
 ## [1.30.1] - 2026-08-24
 
 ### Fixed

--- a/homeassistant-addon/DOCS.md
+++ b/homeassistant-addon/DOCS.md
@@ -731,7 +731,7 @@ Control is **opt-in** via `cbus_aircon_control_enabled` (off by default — it w
 With `cbus_security_app_id` set (default `208`), cgateweb exposes every alarm panel zone as a Home Assistant `binary_sensor` (read-only), plus one `alarm_control_panel` entity per network (see "Alarm panel" below).
 
 - `cbus/read/{network}/208/{zone}/state` — `ON` when the zone is unsealed, open or short; `OFF` when sealed
-- `cbus/read/{network}/208/{zone}/attributes` — JSON with the raw zone state (`sealed`, `unsealed`, `open`, `short`) so automations can distinguish loop faults
+- `cbus/read/{network}/208/{zone}/attributes` — JSON with the raw zone state (`sealed`, `unsealed`, `open`, `short`) so automations can distinguish loop faults. While the panel has bypassed the zone for this armed period, the payload also includes `isolated: true`.
 
 Zone names come from the zone labels under **application 1** in your Toolkit project — import the project via C-Bus Labels and each sensor is named accordingly (zones are announced at startup from these labels; unlabelled zones appear on their first event with a fallback name). A device class is inferred from the name: `pir`/`motion` → motion, `garage` → garage door, `door` → door, `window` → window, `smoke` → smoke.
 
@@ -764,6 +764,8 @@ With both enabled there are two ways to send the `#` keypress from Home Assistan
 - **A separate "Bypass open zones" button** on the panel device, which is easier to call from a script or put on its own dashboard.
 
 Both send exactly the same `SECURITY EMULATE_KEYPAD` command; use whichever suits your setup. Neither appears at all while `cbus_security_bypass_enabled` is off, so you never get a control that silently does nothing.
+
+The panel device also has a **Bypassed zones** diagnostic sensor. Its state is a comma-separated list of zone names (or `none`), with `zones` and `names` attributes for an Activity card or template. Isolation is cleared on disarm.
 
 > This is deliberately never automatic. Bypassing an open zone is a security decision, and only the person who can see the open window should make it — the add-on will not force an arm on your behalf just because a zone is unsealed.
 

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.30.1"
+version: "1.31.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.30.1",
+      "version": "1.31.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.30.1",
+  "version": "1.31.0",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",

--- a/src/eventPublisher.js
+++ b/src/eventPublisher.js
@@ -367,6 +367,22 @@ const READING_KIND_HANDLERS = {
         );
     },
 
+    security_bypassed_zones(ep, base, reading) {
+        // Dashboard list of zones the panel bypassed for this armed period
+        // (#62). State is a comma-separated name list (or "none"); zone ids
+        // and names also ride the attributes topic for templates.
+        ep._publishIfNeeded(
+            `${base}/${MQTT_TOPIC_SUFFIX_STATE}`,
+            reading.state,
+            ep.mqttOptions
+        );
+        ep._publishIfNeeded(
+            `${base}/${MQTT_TOPIC_SUFFIX_ATTRIBUTES}`,
+            JSON.stringify({ zones: reading.zones, names: reading.names }),
+            ep.mqttOptions
+        );
+    },
+
     measurement(ep, base, reading) {
         // Measurement application (app 228): `group` is "{device}/{channel}",
         // so `base` already addresses cbus/read/{net}/{app}/{device}/{channel}.
@@ -654,6 +670,8 @@ class EventPublisher {
      *   security_zone  → cbus/read/{net}/{app}/{zone}/state (ON for unsealed/open/short)
      *                  → cbus/read/{net}/{app}/{zone}/attributes (raw 2-bit state
      *                    name, plus `isolated` while the panel has the zone bypassed)
+     *   security_bypassed_zones → cbus/read/{net}/{app}/panel/bypassed_zones/state
+     *                  → .../attributes (`zones` ids and `names` for dashboards)
      *   measurement    → cbus/read/{net}/{app}/{device}/{channel}/value (decoded number)
      *                  → cbus/read/{net}/{app}/{device}/{channel}/unit (unit string, '' if none)
      *   clock          → cbus/read/{net}/{app}/clock/date ('YYYY-MM-DD') or

--- a/src/haDiscoveryPublishers.js
+++ b/src/haDiscoveryPublishers.js
@@ -1324,6 +1324,9 @@ class _HaDiscoveryPublishers {
                 this._retractEventDrivenConfig(
                     `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_SENSOR}/cgateweb_${network}_${appId}_password_entry/${HA_DISCOVERY_SUFFIX}`
                 );
+                this._retractEventDrivenConfig(
+                    `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_SENSOR}/cgateweb_${network}_${appId}_bypassed_zones/${HA_DISCOVERY_SUFFIX}`
+                );
             },
             create: () => this._createSecurityPanelDiscovery(String(network), String(appId))
         });
@@ -1410,6 +1413,22 @@ class _HaDiscoveryPublishers {
             fields: {
                 state_topic: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/panel/${MQTT_TOPIC_SUFFIX_PASSWORD_ENTRY}`,
                 entity_category: 'diagnostic'
+            },
+            deviceIdentifiers,
+            deviceName,
+            model: 'C-Bus Security Panel'
+        });
+
+        this._finishEventDrivenEntity({
+            discoveryTopic: `${this.settings.ha_discovery_prefix}/${HA_COMPONENT_SENSOR}/cgateweb_${networkId}_${appId}_bypassed_zones/${HA_DISCOVERY_SUFFIX}`,
+            uniqueId: `cgateweb_${networkId}_${appId}_bypassed_zones`,
+            component: HA_COMPONENT_SENSOR,
+            name: 'Bypassed zones',
+            fields: {
+                state_topic: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/panel/bypassed_zones/${MQTT_TOPIC_SUFFIX_STATE}`,
+                json_attributes_topic: `${MQTT_TOPIC_PREFIX_READ}/${networkId}/${appId}/panel/bypassed_zones/${MQTT_TOPIC_SUFFIX_ATTRIBUTES}`,
+                entity_category: 'diagnostic',
+                icon: 'mdi:shield-off-outline'
             },
             deviceIdentifiers,
             deviceName,

--- a/src/securityEventHandler.js
+++ b/src/securityEventHandler.js
@@ -30,6 +30,24 @@ const SYNC_EXEMPT_KINDS = new Set([
     'zone_name_request_echo', 'zone_name', 'password_entry'
 ]);
 
+/** MQTT / Home Assistant sensor state is capped at 255 characters. */
+const BYPASSED_ZONES_STATE_MAX = 255;
+const BYPASSED_ZONES_NONE = 'none';
+
+/**
+ * Comma-separated zone names for the bypassed-zones sensor, or "none".
+ * Truncates to the MQTT state limit; the full lists ride attributes.
+ *
+ * @param {string[]} names
+ * @returns {string}
+ */
+function formatBypassedZoneState(names) {
+    if (!names || names.length === 0) return BYPASSED_ZONES_NONE;
+    const joined = names.join(', ');
+    if (joined.length <= BYPASSED_ZONES_STATE_MAX) return joined;
+    return `${joined.slice(0, BYPASSED_ZONES_STATE_MAX - 3)}...`;
+}
+
 /**
  * Dispatch table for decoded security readings. Unknown kinds fall through to
  * the system-state path (alarm panel + Live Events).
@@ -149,7 +167,8 @@ const LINE_KIND_HANDLERS = {
  * Zone events and status reports publish zone state; panel_trouble readings
  * and system_arm update the panel condition sensors (see securityPanelState);
  * zone_isolated adds an `isolated` attribute to the zone it names (cleared for
- * the whole network on the next disarm); the remaining system-state verbs
+ * the whole network on the next disarm) and updates the panel's bypassed-zones
+ * list sensor; the remaining system-state verbs
  * (arm_ready, exit_delay_started, …) are decoded, logged and surfaced to the
  * Live Events stream only. Arm/disarm writes are not implemented.
  *
@@ -284,6 +303,10 @@ class SecurityEventHandler {
         // routine panel activity, not a request to resend.
         if (trigger !== 'traffic') {
             this.panelState.forgetAlarmState(network);
+            // Panel trouble sensors and the bypassed-zones list are unqueryable
+            // (not in status_report), so a Home Assistant restart would leave
+            // them Unknown unless we republish the last known values (#62).
+            this._republishPersistedDiagnostics(String(network), String(appId));
         }
 
         for (const report of [1, 2]) {
@@ -429,6 +452,7 @@ class SecurityEventHandler {
         if (zone === null || zone === undefined) return;
         if (!this.panelState.setZoneIsolated(network, zone)) return;
         this._publishZoneReading(network, application, zone, this.panelState.lastZoneState(network, zone));
+        this._publishBypassedZones(network, application);
         this._persistPanelState();
     }
 
@@ -456,6 +480,7 @@ class SecurityEventHandler {
             if (zonesPublishedSeparately && zonesPublishedSeparately.has(zone)) continue;
             this._publishZoneReading(network, application, zone, zoneState);
         }
+        this._publishBypassedZones(network, application);
         this.logger.info(`C-Bus Security: zone isolation cleared for ${cleared.length} zone(s) (${network}/${application})`);
         this._persistPanelState();
     }
@@ -508,6 +533,9 @@ class SecurityEventHandler {
         const haDiscovery = this.getHaDiscovery();
         if (haDiscovery && typeof haDiscovery.applySecurityZoneName === 'function') {
             haDiscovery.applySecurityZoneName(reading.network, reading.zone, reading.name);
+        }
+        if (this.panelState.isZoneIsolated(reading.network, reading.zone)) {
+            this._publishBypassedZones(reading.network, reading.application);
         }
     }
 
@@ -571,6 +599,7 @@ class SecurityEventHandler {
         for (const { condition, active } of toPublish) {
             this._publishPanelCondition(network, application, condition, active);
         }
+        if (justAnnounced) this._publishBypassedZones(network, application);
         // Every panel-state change funnels through here (trouble verbs, disarm
         // clears, status-report seeds), so this is the one persist point.
         this._persistPanelState();
@@ -587,6 +616,63 @@ class SecurityEventHandler {
         this.eventPublisher.publishReading(network, application, `panel/${condition}`, {
             kind: 'security_panel', active
         });
+    }
+
+    /**
+     * Re-seed panel diagnostics Home Assistant cannot recover from a status
+     * report: trouble binary_sensors (mains, battery, ...) and the bypassed
+     * zones list. Called on connect/sync/resync, not on routine traffic.
+     *
+     * @param {string} network
+     * @param {string} application
+     * @private
+     */
+    _republishPersistedDiagnostics(network, application) {
+        const haDiscovery = this.getHaDiscovery();
+        if (haDiscovery && typeof haDiscovery.ensureSecurityPanelDiscovery === 'function') {
+            haDiscovery.ensureSecurityPanelDiscovery(network, application);
+        }
+        for (const { condition, active } of this.panelState.initialStates(network)) {
+            this._publishPanelCondition(network, application, condition, active);
+        }
+        this._publishBypassedZones(network, application);
+    }
+
+    /**
+     * Publish the panel's bypassed-zones list for dashboards (#62).
+     *
+     * @param {string} network
+     * @param {string} application
+     * @private
+     */
+    _publishBypassedZones(network, application) {
+        const zones = this.panelState.isolatedZoneIds(network);
+        const names = zones.map((zone) => this._zoneDisplayName(network, zone));
+        this.eventPublisher.publishReading(network, application, 'panel/bypassed_zones', {
+            kind: 'security_bypassed_zones',
+            state: formatBypassedZoneState(names),
+            zones,
+            names
+        });
+        const haDiscovery = this.getHaDiscovery();
+        if (haDiscovery && typeof haDiscovery.ensureSecurityPanelDiscovery === 'function') {
+            haDiscovery.ensureSecurityPanelDiscovery(network, application);
+        }
+    }
+
+    /**
+     * Toolkit application-1 label for a zone, or "Zone N" when unnamed.
+     *
+     * @param {string} network
+     * @param {string} zone
+     * @returns {string}
+     * @private
+     */
+    _zoneDisplayName(network, zone) {
+        const haDiscovery = this.getHaDiscovery();
+        const labelMap = haDiscovery && haDiscovery.labelMap;
+        const labelled = labelMap && labelMap.get(securityZoneLabelKey(network, zone));
+        return labelled || `Zone ${zone}`;
     }
 
     /**

--- a/src/securityPanelState.js
+++ b/src/securityPanelState.js
@@ -241,6 +241,19 @@ class SecurityPanelState {
     }
 
     /**
+     * Isolated (bypassed) zone ids for a network, sorted numerically so a
+     * dashboard list is stable across republishes.
+     *
+     * @param {string|number} network
+     * @returns {string[]}
+     */
+    isolatedZoneIds(network) {
+        const entry = this._zonesByNetwork.get(String(network));
+        if (!entry || entry.isolated.size === 0) return [];
+        return [...entry.isolated].sort((a, b) => Number(a) - Number(b));
+    }
+
+    /**
      * Record that the panel isolated (bypassed) a zone for this armed period.
      *
      * Returns false for a repeat so callers publish transitions only — a panel

--- a/tests/eventPublisher.test.js
+++ b/tests/eventPublisher.test.js
@@ -882,6 +882,20 @@ describe('EventPublisher', () => {
             );
         });
 
+        it('should publish the bypassed-zones list state and attributes', () => {
+            publish('panel/bypassed_zones', {
+                kind: 'security_bypassed_zones',
+                state: 'Front Door, Kitchen Window',
+                zones: ['7', '44'],
+                names: ['Kitchen Window', 'Front Door']
+            }, '254', '208');
+            expectCall('cbus/read/254/208/panel/bypassed_zones/state', 'Front Door, Kitchen Window');
+            expectCall(
+                'cbus/read/254/208/panel/bypassed_zones/attributes',
+                '{"zones":["7","44"],"names":["Kitchen Window","Front Door"]}'
+            );
+        });
+
         it('should keep the non-isolated attributes payload byte-identical for every zone state', () => {
             // The overwhelmingly common publish. Asserted as exact strings, not
             // parsed objects, so any regression in the pre-rendered payloads —

--- a/tests/haDiscovery.test.js
+++ b/tests/haDiscovery.test.js
@@ -3220,8 +3220,9 @@ describe('HaDiscovery — discovery config replay (issue #44)', () => {
         d.ensureSecurityPanelDiscovery('254', '208');
         publishFn.mockClear();
 
-        // 2 zones × (zone + loop-fault) + 9 panel conditions + 1 alarm + 1 password-entry
-        expect(d.republishDiscoveryConfigs()).toBe(15);
+        // 2 zones × (zone + loop-fault) + 9 panel conditions + 1 alarm
+        // + 1 password-entry + 1 bypassed-zones
+        expect(d.republishDiscoveryConfigs()).toBe(16);
     });
 
     it('does not replay a retracted config', () => {

--- a/tests/securityDiscovery.test.js
+++ b/tests/securityDiscovery.test.js
@@ -518,6 +518,34 @@ describe('HaDiscovery — app 208 security zones', () => {
             expect(call[1]).toBe(''); // empty retained payload removes the entity
         });
     });
+
+    describe('bypassed zones sensor (#62)', () => {
+        const TOPIC = 'homeassistant/sensor/cgateweb_254_208_bypassed_zones/config';
+
+        function payload() {
+            const call = publishFn.mock.calls.find(c => c[0] === TOPIC);
+            return call && JSON.parse(call[1]);
+        }
+
+        it('publishes a diagnostic sensor on the panel device', () => {
+            d.ensureSecurityPanelDiscovery('254', '208');
+            const p = payload();
+            expect(p).toBeDefined();
+            expect(p.name).toBe('Bypassed zones');
+            expect(p.entity_category).toBe('diagnostic');
+            expect(p.state_topic).toBe('cbus/read/254/208/panel/bypassed_zones/state');
+            expect(p.json_attributes_topic).toBe('cbus/read/254/208/panel/bypassed_zones/attributes');
+            expect(p.device.identifiers).toEqual(['cgateweb_254_208_panel']);
+        });
+
+        it('retracts the sensor when the panel is excluded', () => {
+            d.exclude.add('254/208/panel');
+            d.ensureSecurityPanelDiscovery('254', '208');
+            const call = publishFn.mock.calls.find(c => c[0] === TOPIC);
+            expect(call).toBeDefined();
+            expect(call[1]).toBe('');
+        });
+    });
 });
 
 describe('securityZoneLabels — label-key convention', () => {

--- a/tests/securityEventHandler.test.js
+++ b/tests/securityEventHandler.test.js
@@ -351,6 +351,59 @@ describe('SecurityEventHandler', () => {
             ]);
         });
 
+        it('publishes a dashboard list of bypassed zone names', () => {
+            const deps = makeDeps({
+                getHaDiscovery: () => ({
+                    labelMap: new Map([['254/1/44', 'Front Door'], ['254/1/7', 'Kitchen Window']]),
+                    ensureSecurityZoneDiscovery: jest.fn(),
+                    ensureSecurityPanelDiscovery: jest.fn()
+                })
+            });
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine('# security zone_isolated //MIDSTRM/254/208/44  #sourceunit=18 OID=');
+            handler.handleLine('# security zone_isolated //MIDSTRM/254/208/7  #sourceunit=18 OID=');
+
+            const lists = deps.eventPublisher.publishReading.mock.calls
+                .filter(c => c[3] && c[3].kind === 'security_bypassed_zones')
+                .map(c => c[3]);
+            expect(lists.at(-1)).toEqual({
+                kind: 'security_bypassed_zones',
+                state: 'Kitchen Window, Front Door',
+                zones: ['7', '44'],
+                names: ['Kitchen Window', 'Front Door']
+            });
+        });
+
+        it('falls back to Zone N when a bypassed zone has no Toolkit label', () => {
+            const deps = makeDeps();
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine(ZONE_ISOLATED_LINE);
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/bypassed_zones', {
+                    kind: 'security_bypassed_zones',
+                    state: 'Zone 44',
+                    zones: ['44'],
+                    names: ['Zone 44']
+                }
+            );
+        });
+
+        it('clears the bypassed-zones list on disarm', () => {
+            const deps = makeDeps();
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine(ZONE_ISOLATED_LINE);
+            deps.eventPublisher.publishReading.mockClear();
+            handler.handleLine(DISARM_LINE);
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/bypassed_zones', {
+                    kind: 'security_bypassed_zones',
+                    state: 'none',
+                    zones: [],
+                    names: []
+                }
+            );
+        });
+
         it('leaves isolation alone for a status report that does not say disarmed', () => {
             const deps = makeDeps();
             const handler = new SecurityEventHandler(deps);
@@ -758,6 +811,44 @@ describe('SecurityEventHandler', () => {
             handler.requestStatusSync('254', 'resync');
             handler.handleLine(STATUS_REPORT_1_LINE);
             expect(alarmPublishes()).toHaveLength(2);
+        });
+
+        it('republishes panel diagnostics on resync so they are not unknown after an HA restart', () => {
+            const deps = makeDeps({ cbusname: 'MIDSTRM', sendCommand: jest.fn() });
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine('# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=');
+            handler.handleLine('# security zone_isolated //MIDSTRM/254/208/44  #sourceunit=18 OID=');
+            deps.eventPublisher.publishReading.mockClear();
+
+            handler.requestStatusSync('254', 'resync');
+
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/mains', { kind: 'security_panel', active: true }
+            );
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/battery', { kind: 'security_panel', active: false }
+            );
+            expect(deps.eventPublisher.publishReading).toHaveBeenCalledWith(
+                '254', '208', 'panel/bypassed_zones', {
+                    kind: 'security_bypassed_zones',
+                    state: 'Zone 44',
+                    zones: ['44'],
+                    names: ['Zone 44']
+                }
+            );
+        });
+
+        it('does not republish panel diagnostics for routine traffic', () => {
+            const deps = makeDeps({ cbusname: 'MIDSTRM', sendCommand: jest.fn() });
+            const handler = new SecurityEventHandler(deps);
+            handler.handleLine('# security mains_failure //MIDSTRM/254/208  #sourceunit=18 OID=');
+            const panelPublishes = () => deps.eventPublisher.publishReading.mock.calls
+                .filter(c => c[3] && c[3].kind === 'security_panel');
+            const before = panelPublishes().length;
+
+            handler.handleLine(ZONE_UNSEALED_LINE);
+
+            expect(panelPublishes()).toHaveLength(before);
         });
 
         it('does not republish alarm state for routine panel traffic', () => {

--- a/tests/securityPanelState.test.js
+++ b/tests/securityPanelState.test.js
@@ -201,6 +201,14 @@ describe('SecurityPanelState — zone isolation', () => {
         expect(state.setZoneIsolated('254', '44')).toBe(false);
     });
 
+    it('lists isolated zone ids in numeric order', () => {
+        expect(state.isolatedZoneIds('254')).toEqual([]);
+        state.setZoneIsolated('254', '44');
+        state.setZoneIsolated('254', '7');
+        expect(state.isolatedZoneIds('254')).toEqual(['7', '44']);
+        expect(state.isolatedZoneIds('200')).toEqual([]);
+    });
+
     it('keeps isolation per network and per zone', () => {
         state.setZoneIsolated('254', '44');
         expect(state.isZoneIsolated('254', '45')).toBe(false);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up from [#62](https://github.com/dougrathbone/cgateweb/issues/62): after force-arm shipped, there was still no list of bypassed zones for a dashboard Activity card, and alarm panel diagnostics went Unknown after a Home Assistant restart.

## Changes

- Diagnostic **Bypassed zones** sensor on the security panel device. State is a comma-separated name list (or `none`); `zones` and `names` attributes are there for templates.
- The list updates when the panel isolates or disarms, and uses Toolkit application-1 labels when present.
- On connect, network sync, and HA-restart resync, republish persisted panel trouble sensors (mains, battery, and the rest) plus the bypassed-zones list. Those are not in `status_report`, so they were never resent with the existing zone resync.
- Release **1.31.0**.

## Test plan

- [x] `npm test` passes locally with no failures
- [x] New unit coverage for the list sensor, isolation ordering, resync republish, and discovery
- [x] Existing tests were not broken or removed without justification

## Checklist

- [x] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [x] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c4b3368-0fd9-4d85-963d-1d1580693a5a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c4b3368-0fd9-4d85-963d-1d1580693a5a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

