### PR TITLE
Keep the latency benchmark out of default unit CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "testPathIgnorePatterns": [
       "<rootDir>/node_modules/",
       "<rootDir>/.claude/",
-      "<rootDir>/.worktrees/"
+      "<rootDir>/.worktrees/",
+      "<rootDir>/tests/perf/"
     ],
     "collectCoverageFrom": [
       "src/**/*.js",

--- a/tests/perf/latencyBenchmark.test.js
+++ b/tests/perf/latencyBenchmark.test.js
@@ -1,3 +1,6 @@
+// Invoked by `npm run perf:raw` / `perf:dedup`, not by `npm test`.
+// Default Jest ignores this directory: the workload is a microbenchmark and
+// flakes under coverage on shared CI runners.
 const fs = require('fs');
 const path = require('path');
 const { performance } = require('perf_hooks');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Master CI after the 1.33.0 merge failed on Node 22 because the mocked latency benchmark ran inside the default unit suite under coverage. That failed job skipped C-Gate integration (it needs the test matrix), so the required integration aggregator also failed.

Keep the benchmark behind `npm run perf:raw` / `perf:dedup` so unit CI is not a load test.

## Changes

- Ignore `tests/perf/` in default Jest
- Note in the benchmark file that it is not part of `npm test`

## Test plan

- [x] `npm test` passes locally with no failures (3039 tests; the benchmark file is excluded)
- [x] New code has unit test coverage (aim for ≥ 60% on changed files)
- [x] Existing tests were not broken or removed without justification

## Checklist

- [ ] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [ ] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0428a-d53d-7f59-b8e5-4fb542f09d3c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0428a-d53d-7f59-b8e5-4fb542f09d3c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

