### PR TITLE
Fix pool connect timeout, tighten bridge tests, gate all add-on image arches

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -199,7 +199,10 @@ jobs:
 
   addon-image:
     timeout-minutes: 30
-    name: Build add-on image (${{ matrix.arch }})
+    # Display name is not the required check. Branch protection requires
+    # "Build add-on image (amd64)", which is the aggregator below so that a
+    # 32-bit (or any other arch) failure cannot merge while amd64 is green.
+    name: Add-on image (${{ matrix.arch }})
     runs-on: ubuntu-latest
     # Build the real add-on image for every architecture the add-on ships to,
     # so arch-specific breakage (base image tags, native modules under
@@ -207,9 +210,8 @@ jobs:
     # builds run under QEMU binfmt emulation.
     #
     # The JOB always runs even when run-expensive is false, and gates its steps
-    # instead. "Build add-on image (amd64)" is a required status check, and a
-    # skipped job does not satisfy one - skipping the job outright would leave
-    # every docs-only PR permanently unmergeable.
+    # instead. A skipped job does not satisfy a required check - skipping this
+    # outright would leave every docs-only PR permanently unmergeable.
     strategy:
       fail-fast: false
       matrix:
@@ -311,6 +313,50 @@ jobs:
           test -d /app/node_modules
           node -e "require(\"/app/package.json\")"
         '
+
+  # Required status check. The name is load-bearing: master's branch protection
+  # already requires "Build add-on image (amd64)". The matrix jobs above are
+  # not individually required; this aggregator fails if any architecture
+  # failed, which is what makes i386/armv7/armhf/aarch64 merge-blocking
+  # without a branch-protection API change.
+  #
+  # Same skip contract as addon-image itself: the matrix jobs still run (and
+  # succeed) when run-expensive is false, so this job stays green on docs PRs.
+  addon-image-gate:
+    timeout-minutes: 5
+    name: Build add-on image (amd64)
+    runs-on: ubuntu-latest
+    needs: addon-image
+    if: always()
+    steps:
+    - name: Verify every architecture image build passed
+      env:
+        MATRIX_RESULT: ${{ needs.addon-image.result }}
+        RUN_EXPENSIVE: ${{ inputs.run-expensive }}
+        REASON: ${{ inputs.expensive-skip-reason }}
+      run: |
+        echo "add-on image matrix: $MATRIX_RESULT (run-expensive=${RUN_EXPENSIVE})"
+
+        if [[ "$MATRIX_RESULT" == "failure" || "$MATRIX_RESULT" == "cancelled" ]]; then
+          echo "::error::One or more add-on image builds failed (${MATRIX_RESULT})."
+          exit 1
+        fi
+
+        if [[ "$RUN_EXPENSIVE" != "true" ]]; then
+          echo "::notice::Add-on image builds skipped: ${REASON}."
+          {
+            echo "### Add-on image builds skipped"
+            echo ""
+            echo "${REASON}, so the built image cannot have changed."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
+
+        if [[ "$MATRIX_RESULT" != "success" ]]; then
+          echo "::error::Add-on image matrix result was '${MATRIX_RESULT}', expected success."
+          exit 1
+        fi
+        echo "All architecture add-on image builds passed."
 
   # Boot the full managed stack against each openly-downloadable C-Gate version
   # so version-specific regressions (e.g. the 3.7.x TREEXML addressing bug, #23)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,7 +45,7 @@ That job — and the whole quality gate — lives in `.github/workflows/quality.
 Two consequences worth knowing before touching it:
 
 - **Check names are `quality / <job name>`** and several are required status checks on master. Renaming a job in `quality.yml` breaks branch protection until the required contexts are updated to match (`gh api -X PATCH repos/dougrathbone/cgateweb/branches/master/protection/required_status_checks`).
-- **Docs-only changes skip the image builds and integration legs.** `ci.yml`'s `changes` job decides, and passes `run-expensive` in. `addon-image` gates its *steps* rather than skipping the job, because a skipped job does not satisfy a required check — skipping it outright would make every docs PR unmergeable. The integration legs are not individually required, so those skip wholesale and the aggregator reports why.
+- **Docs-only changes skip the image builds and integration legs.** `ci.yml`'s `changes` job decides, and passes `run-expensive` in. `addon-image` gates its *steps* rather than skipping the job, because a skipped job does not satisfy a required check — skipping it outright would make every docs PR unmergeable. The required image check is `quality / Build add-on image (amd64)`, implemented as an aggregator over the whole arch matrix (not the amd64 cell alone), so a 32-bit image failure cannot merge. The integration legs are not individually required, so those skip wholesale and the aggregator reports why.
 
 After tagging, `hacs-distribution.yml` creates GitHub Releases on **both** the distribution repo and this source repo (notes from `homeassistant-addon/CHANGELOG.md`). You no longer need to backfill the source release by hand.
 

--- a/src/cgateConnectionPool.js
+++ b/src/cgateConnectionPool.js
@@ -279,7 +279,26 @@ class CgateConnectionPool extends EventEmitter {
             
             connection.poolIndex = index;
             connection.lastActivity = Date.now();
-            
+
+            // Wrap resolve/reject BEFORE connect() and BEFORE the 'connect'
+            // handler. connect() can emit synchronously (tests do; a reused
+            // socket can too), and assigning the wrappers afterwards left the
+            // establishment timer running after a successful connect.
+            let settled = false;
+            const timeoutId = setTimeout(() => {
+                if (settled) return;
+                settled = true;
+                reject(new Error(
+                    `Connection ${index} establishment timed out after ${this.connectionTimeout}ms`
+                ));
+            }, this.connectionTimeout);
+            const finish = (cb) => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timeoutId);
+                cb();
+            };
+
             // Connection event handlers
             connection.on('connect', () => {
                 this.logger.info(`Pool connection ${index} established`);
@@ -287,7 +306,7 @@ class CgateConnectionPool extends EventEmitter {
                 this.connectionInFlight.set(connection, 0);
                 connection.lastActivity = Date.now();
                 this.emit('connectionAdded', { index, connection });
-                resolve(connection);
+                finish(() => resolve(connection));
             });
             
             connection.on('close', (hadError) => {
@@ -335,25 +354,7 @@ class CgateConnectionPool extends EventEmitter {
             
             // Store connection and attempt to connect
             this.connections[index] = connection;
-            
-            // Set timeout for connection establishment
-            const timeoutId = setTimeout(() => {
-                reject(new Error(`Connection ${index} establishment timed out after ${this.connectionTimeout}ms`));
-            }, this.connectionTimeout);
-            
             connection.connect();
-            
-            // Clear timeout on resolution
-            const originalResolve = resolve;
-            const originalReject = reject;
-            resolve = (...args) => {
-                clearTimeout(timeoutId);
-                originalResolve(...args);
-            };
-            reject = (...args) => {
-                clearTimeout(timeoutId);
-                originalReject(...args);
-            };
         });
     }
     

--- a/tests/cgateConnectionPool.test.js
+++ b/tests/cgateConnectionPool.test.js
@@ -541,6 +541,28 @@ describe('CgateConnectionPool', () => {
 
             await smallPool.stop();
         });
+
+        it('clears the establishment timeout so a later timer fire cannot reject a live connection', async () => {
+            CgateConnection.mockImplementation(() => makeMockConnection());
+            const smallPool = new CgateConnectionPool('command', '192.168.1.100', 20023, {
+                ...mockSettings,
+                connectionPoolSize: 1,
+                connectionTimeout: 2000
+            });
+            const clearSpy = jest.spyOn(global, 'clearTimeout');
+
+            await smallPool.start();
+            expect(smallPool.healthyConnections.size).toBe(1);
+            expect(clearSpy).toHaveBeenCalled();
+
+            jest.advanceTimersByTime(5000);
+            await Promise.resolve();
+            expect(smallPool.healthyConnections.size).toBe(1);
+            expect(smallPool.healthyConnections.has(smallPool.connections[0])).toBe(true);
+
+            clearSpy.mockRestore();
+            await smallPool.stop();
+        });
     });
 
     describe('stop()', () => {

--- a/tests/cgateWebBridge.test.js
+++ b/tests/cgateWebBridge.test.js
@@ -11,29 +11,40 @@ const EventEmitter = require('events');
 // its subscriptions attached and events fired by a later test also run every
 // earlier test's handlers against a half-torn-down bridge.
 const mockConnectionPool = new EventEmitter();
+
+function setPoolHealthyCount(count) {
+    const connections = [];
+    const healthy = new Set();
+    for (let i = 0; i < count; i++) {
+        const conn = { poolIndex: i };
+        connections.push(conn);
+        healthy.add(conn);
+    }
+    mockConnectionPool.connections = connections;
+    mockConnectionPool.healthyConnections = healthy;
+}
+
 mockConnectionPool.start = jest.fn().mockImplementation(async () => {
     mockConnectionPool.isStarted = true;
-    mockConnectionPool.healthyConnections = { size: 3 };
-    mockConnectionPool.connections = [{ poolIndex: 0 }, { poolIndex: 1 }, { poolIndex: 2 }];
+    setPoolHealthyCount(3);
     setImmediate(() => mockConnectionPool.emit('started', { healthy: 3, total: 3 }));
 });
 mockConnectionPool.stop = jest.fn().mockImplementation(async () => {
     mockConnectionPool.isStarted = false;
-    mockConnectionPool.healthyConnections = { size: 0 };
-    mockConnectionPool.connections = [];
+    setPoolHealthyCount(0);
     setImmediate(() => mockConnectionPool.emit('stopped'));
 });
 mockConnectionPool.execute = jest.fn().mockImplementation(async () => true);
 mockConnectionPool.getStats = jest.fn(() => ({
     poolSize: 3,
-    totalConnections: 3,
-    healthyConnections: 3,
+    totalConnections: mockConnectionPool.connections.length,
+    healthyConnections: mockConnectionPool.healthyConnections.size,
+    writableConnections: mockConnectionPool.healthyConnections.size,
     isStarted: mockConnectionPool.isStarted || false,
     isShuttingDown: false
 }));
 mockConnectionPool.isStarted = false;
-mockConnectionPool.healthyConnections = { size: 0 };
-mockConnectionPool.connections = [];
+setPoolHealthyCount(0);
 
 jest.mock('../src/cgateConnectionPool', () => {
     return jest.fn().mockImplementation(() => mockConnectionPool);
@@ -45,8 +56,6 @@ mockMqttClient.connect = jest.fn();
 mockMqttClient.subscribe = jest.fn((topic, options, callback) => callback ? callback(null) : null);
 mockMqttClient.publish = jest.fn();
 mockMqttClient.end = jest.fn();
-mockMqttClient.removeAllListeners = jest.fn();
-mockMqttClient.on = jest.fn(); 
 jest.mock('mqtt', () => ({
     connect: jest.fn(() => mockMqttClient) 
 }));
@@ -74,15 +83,15 @@ describe('CgateWebBridge', () => {
         mockConnectionPool.execute.mockClear();
         mockConnectionPool.getStats.mockClear();
         mockConnectionPool.isStarted = false;
-        mockConnectionPool.healthyConnections = { size: 0 };
-        mockConnectionPool.connections = [];
+        setPoolHealthyCount(0);
         
-        // Reset MQTT mocks
-        mockMqttClient.removeAllListeners.mockClear();
+        // Reset MQTT mocks. Leave EventEmitter.on intact so MqttManager.connect()
+        // actually wires client events; clear listeners so they do not leak
+        // across tests that share this module-scoped client.
+        mockMqttClient.removeAllListeners();
         mockMqttClient.subscribe.mockClear();
         mockMqttClient.publish.mockClear();
         mockMqttClient.end.mockClear();
-        mockMqttClient.on.mockClear();
         const mqtt = require('mqtt');
         mqtt.connect.mockClear();
 
@@ -182,6 +191,7 @@ describe('CgateWebBridge', () => {
         // listeners have to be dropped explicitly (bridge.stop() would do it,
         // but the teardown above deliberately stops short of a full stop()).
         mockConnectionPool.removeAllListeners();
+        mockMqttClient.removeAllListeners();
 
         jest.clearAllTimers();
         mockConsoleWarn.mockClear();
@@ -390,6 +400,19 @@ describe('CgateWebBridge', () => {
                 cmdPoolStartSpy.mockRestore();
                 evtConnectSpy.mockRestore();
             });
+
+            it('wires MQTT client events through to the manager', async () => {
+                await bridge.start();
+
+                const connected = new Promise((resolve) => {
+                    bridge.mqttManager.once('connect', resolve);
+                });
+                mockMqttClient.emit('connect');
+                await connected;
+
+                expect(bridge.mqttManager.connected).toBe(true);
+                expect(mockMqttClient.subscribe).toHaveBeenCalled();
+            });
         });
 
         describe('stop()', () => {
@@ -487,7 +510,7 @@ describe('CgateWebBridge', () => {
                 bridge.settings.getallperiod = 5; // 5 seconds (not milliseconds)
                 bridge.mqttManager.connected = true;
                 bridge.commandConnectionPool.isStarted = true;
-                bridge.commandConnectionPool.healthyConnections = { size: 3 };
+                setPoolHealthyCount(3);
                 bridge.eventConnection.connected = true;
 
                 bridge._handleAllConnected();
@@ -507,7 +530,7 @@ describe('CgateWebBridge', () => {
                 bridge.settings.ha_discovery_enabled = true;
                 bridge.mqttManager.connected = true;
                 bridge.commandConnectionPool.isStarted = true;
-                bridge.commandConnectionPool.healthyConnections = { size: 3 };
+                setPoolHealthyCount(3);
                 bridge.eventConnection.connected = true;
 
                 // Mock haDiscovery since it gets created in _handleAllConnected
@@ -585,7 +608,7 @@ describe('CgateWebBridge', () => {
                 isStarted: true,
                 isShuttingDown: false
             });
-            mockConnectionPool.healthyConnections = { size: 0 };
+            setPoolHealthyCount(0);
 
             mockConnectionPool.emit('allConnectionsUnhealthy');
 
@@ -1601,6 +1624,80 @@ describe('CgateWebBridge', () => {
                     { retain: false }
                 );
             });
+
+            it('_getAdaptiveQueueIntervalMs halves when queue depth exceeds writableConnections * 20', () => {
+                bridge.settings.messageinterval = 200;
+                bridge.settings.messageIntervalMinMs = 1;
+                bridge.settings.commandMinIntervalMs = 1;
+                bridge.settings.commandMinIntervalFloorMs = 1;
+                bridge.commandConnectionPool.getStats = jest.fn(() => ({
+                    isStarted: true,
+                    isShuttingDown: false,
+                    healthyConnections: 2,
+                    writableConnections: 2
+                }));
+                Object.defineProperty(bridge.cgateCommandQueue, 'length', { get: () => 41, configurable: true });
+                expect(bridge._getAdaptiveQueueIntervalMs()).toBe(50); // (200 / 2) * 0.5
+            });
+
+            it('stalls the real command queue until the mocked pool recovers', async () => {
+                jest.useFakeTimers();
+                try {
+                mockConnectionPool.isStarted = true;
+                setPoolHealthyCount(3);
+                mockConnectionPool.getStats.mockImplementation(() => ({
+                    isStarted: mockConnectionPool.isStarted,
+                    isShuttingDown: false,
+                    healthyConnections: mockConnectionPool.healthyConnections.size,
+                    writableConnections: mockConnectionPool.healthyConnections.size
+                }));
+                mockConnectionPool.execute.mockImplementation(async () => true);
+
+                bridge.settings.messageinterval = 50;
+                bridge.settings.maxQueueSize = 3;
+                bridge.settings.queueRetryWhenBlockedMinMs = 20;
+                bridge.settings.queueRetryWhenBlockedCapMs = 20;
+                bridge._buildQueues();
+
+                const publishSpy = jest.spyOn(bridge.mqttManager, 'publish');
+
+                bridge.cgateCommandQueue.add('CMD_A\n');
+                await Promise.resolve();
+                await Promise.resolve();
+                expect(mockConnectionPool.execute).toHaveBeenCalledWith('CMD_A\n');
+
+                mockConnectionPool.execute.mockClear();
+                mockConnectionPool.healthyConnections.clear();
+
+                bridge.cgateCommandQueue.add('CMD_B\n');
+                await Promise.resolve();
+                jest.advanceTimersByTime(200);
+                await Promise.resolve();
+                expect(mockConnectionPool.execute).not.toHaveBeenCalled();
+                expect(bridge.cgateCommandQueue.length).toBeGreaterThan(0);
+
+                bridge.cgateCommandQueue.add('CMD_C\n');
+                bridge.cgateCommandQueue.add('CMD_D\n');
+                bridge.cgateCommandQueue.add('CMD_E\n');
+                expect(publishSpy).toHaveBeenCalledWith(
+                    'hello/cgateweb/warnings',
+                    expect.stringContaining('C-Gate command queue full'),
+                    { retain: false }
+                );
+
+                setPoolHealthyCount(3);
+                for (let i = 0; i < 20 && bridge.cgateCommandQueue.length > 0; i++) {
+                    jest.advanceTimersByTime(50);
+                    await Promise.resolve();
+                    await Promise.resolve();
+                }
+
+                expect(mockConnectionPool.execute).toHaveBeenCalled();
+                expect(bridge.cgateCommandQueue.length).toBe(0);
+            } finally {
+                jest.useRealTimers();
+            }
+        });
         });
 
         describe('EventPublisher direct publish', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Three follow-ups from the codebase review: a real connection-pool timer leak, bridge tests that did not match production types, and the required add-on image check only covering amd64.

## Changes

- Command-pool `_createConnection` now wraps settle/timeout before `connect()`, so a successful establish clears the timer instead of leaving it running.
- Bridge tests use a real `Set` for `healthyConnections`, leave MQTT `EventEmitter.on` intact, and cover pool exhaustion through the real throttled queue (stall, drop warning, recover) plus the queue-depth interval multiplier.
- The required check name `Build add-on image (amd64)` is now an aggregator over the whole image matrix. A 32-bit (or any other arch) failure fails that check. Docs-only PRs still succeed because the matrix jobs keep running and skip their build steps.

## Test plan

- [x] `npm test` passes locally with no failures (3043 tests)
- [x] `npm run lint` and `npm run typecheck` pass
- [x] New pool timeout and bridge queue/MQTT tests included
- [ ] CI `quality / Build add-on image (amd64)` is the aggregator and fails if any matrix arch fails

## Checklist

- [ ] Version bumped in `package.json` and `homeassistant-addon/config.yaml` (if releasing)
- [ ] `CHANGELOG.md` updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05d1a-343f-78ac-9aa6-e5d666e31df8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05d1a-343f-78ac-9aa6-e5d666e31df8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

