### PR TITLE
chore: release v1.34.0

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -533,8 +533,16 @@ jobs:
           exit 0
         fi
 
+        # A leg that skipped while run-expensive is true did not opt out: its
+        # `needs` failed, so the unit tests (or another upstream) went red and
+        # the leg never ran. Say that rather than blaming the integration
+        # tests, which reads as a C-Gate failure and sends you to the wrong log.
+        if [[ "$DOWNLOAD_RESULT" == "skipped" ]]; then
+          echo "::error::The download-mode C-Gate integration legs never ran because an upstream job failed. Check the unit test job."
+          exit 1
+        fi
         if [[ "$DOWNLOAD_RESULT" != "success" ]]; then
-          echo "::error::One or more download-mode C-Gate integration tests failed."
+          echo "::error::One or more download-mode C-Gate integration tests failed (result: ${DOWNLOAD_RESULT})."
           exit 1
         fi
         if [[ "$REQUIRE_UPLOAD" == "true" ]]; then

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.com/dougrathbone).
 
+## [1.34.0] - 2026-09-02
+
+### Changed
+
+- Internal: command connections no longer leave a leftover connect timer, and add-on image CI now fails the merge check if any architecture build fails.
+
 ## [1.33.0] - 2026-08-27
 
 ### Added

--- a/homeassistant-addon/config.yaml
+++ b/homeassistant-addon/config.yaml
@@ -1,5 +1,5 @@
 name: "C-Gate Web Bridge"
-version: "1.33.0"
+version: "1.34.0"
 slug: cgateweb
 description: "Bridge between Clipsal C-Bus systems and MQTT/Home Assistant"
 url: "https://github.com/dougrathbone/cgateweb"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cgateweb",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cgateweb",
-      "version": "1.33.0",
+      "version": "1.34.0",
       "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cgateweb",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "description": "Node.js bridge connecting Clipsal C-Bus automation systems to MQTT for Home Assistant integration",
   "keywords": [
     "cbus",

--- a/tests/cgateProjectSerialFixup.test.js
+++ b/tests/cgateProjectSerialFixup.test.js
@@ -24,6 +24,15 @@ describe('cgateweb-project-serial-fixup (issue #28)', () => {
     let tmpDir;
     let dbPath;
 
+    // Compile the sql.js WASM module once, up front. Instantiating it costs
+    // seconds on a loaded CI runner with coverage instrumentation, and without
+    // this the whole cost landed on whichever test ran first, flaking it
+    // against the default 5s per-test timeout while every later test reused
+    // the cached module and passed.
+    beforeAll(async () => {
+        await initSqlJs();
+    }, 60000);
+
     beforeEach(() => {
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'serial-fixup-'));
         dbPath = path.join(tmpDir, 'TEST.db');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Minor release 1.34.0 after merging #95, plus a fix for the CI flake that turned the first release run red.

## Changes

- Version 1.34.0 in package.json, package-lock.json, and the add-on config
- Changelog: command-pool connect timeout cleanup and all-architecture add-on image CI gate
- Warm the sql.js WASM module in beforeAll for the project serial-fixup tests. Instantiating it costs seconds on a loaded runner with coverage on, and the whole cost landed on whichever test ran first, flaking it against the default 5s per-test timeout while later tests reused the cached module. It failed the first release run and the master merge run, on different Node versions, with an empty error body.
- The integration aggregator now distinguishes a leg skipped by an upstream failure from a leg that actually failed. The old message blamed C-Gate integration when the unit tests were the cause.

## Test plan

- [x] npm test, lint, and typecheck pass locally (3043 tests)
- [x] package.json and config.yaml versions match
- [x] Serial-fixup suite passes after a clean npm ci

## Checklist

- [x] Version bumped in package.json and homeassistant-addon/config.yaml (if releasing)
- [x] CHANGELOG.md updated (if releasing)
- [x] No sensitive data or credentials included

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a05d1a-343f-78ac-9aa6-e5d666e31df8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a05d1a-343f-78ac-9aa6-e5d666e31df8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

