### PR TITLE
Fix the label-watcher flake that failed the v1.34.0 release, and catch this class of failure nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ on:
   pull_request:
     branches: [ "main", "master" ]
   schedule:
-    # Daily pulse so a Schneider download-portal change (they repackaged the
-    # C-Gate zip once already, breaking fresh installs) is caught by the
-    # cgate-download-check job even when nothing is pushed. Scheduled
-    # workflows only run on the default branch.
+    # Daily pulse for the things a push cannot tell us about: a Schneider
+    # download-portal change (they repackaged the C-Gate zip once already,
+    # breaking fresh installs), a nondeterministic test, and a release that
+    # never reached the add-on repository. Scheduled workflows only run on the
+    # default branch.
     - cron: '23 4 * * *'
 
 # Restrict the default GITHUB_TOKEN to read-only. No job here writes to the
@@ -147,9 +148,10 @@ jobs:
   # a zip). Deliberately NOT in the required status checks: a failure is a
   # loud signal, but a third-party outage must not block merges.
   #
-  # This is also the only job a scheduled run performs. The quality gate above
-  # is skipped on schedule: re-running the whole pipeline daily against an
-  # unchanged master proved nothing and cost ~20 runner-minutes a day.
+  # The quality gate above is still skipped on schedule: re-running the whole
+  # pipeline daily against an unchanged master costs ~20 runner-minutes for no
+  # signal. The two jobs below are the exceptions - each answers a question a
+  # push cannot, for about a minute of runner time.
   cgate-download-check:
     name: Verify C-Gate download (${{ matrix.cgate.version }})
     runs-on: ubuntu-latest
@@ -312,3 +314,113 @@ jobs:
           exit 1
         fi
         echo "ci-assets C-Gate ${{ matrix.cgate.version }} verified."
+
+  # Repeat the unit suite on an unchanged master to catch tests that only fail
+  # sometimes. A flaky test is invisible on a push - the run that hit it is
+  # attributed to whatever change happened to be in flight, and a re-run makes
+  # it green - so the first place it reliably bites is the release, where the
+  # gate runs again on the tag and a red run blocks distribution after the
+  # version has already been tagged and the changelog published. That is
+  # exactly how v1.34.0 was tagged but never reached anyone's Home Assistant.
+  #
+  # Cheap enough to be worth it daily: the suite takes well under a minute, so
+  # three passes on each supported Node version is a couple of runner-minutes.
+  # Node 20 is included deliberately - the flake that cost v1.34.0 only ever
+  # reproduced there.
+  flake-watch:
+    name: Repeat unit tests (${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event_name == 'schedule'
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [20.x, 22.x]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020  # v7.0.0
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Run the unit suite three times
+      run: |
+        set -uo pipefail
+        FAILED=0
+        for pass in 1 2 3; do
+          echo "=== Pass ${pass}/3 ==="
+          if ! npm test; then
+            echo "::error::Unit suite failed on pass ${pass} of 3 against an unchanged master. This is a nondeterministic test - fix it before it fails a release."
+            FAILED=1
+          fi
+        done
+        exit "${FAILED}"
+
+  # Did the last release actually reach the add-on repository Home Assistant
+  # installs from? Nothing else asks. A tag push runs the whole quality gate
+  # again, so anything from a flaky test to an expired deploy token leaves the
+  # source repo looking released - tag, changelog, GitHub release - while
+  # Supervisor still offers the previous version. v1.34.0 sat like that for a
+  # day and was found only because a user reported a bug that was already
+  # fixed in it.
+  distribution-drift-check:
+    name: Verify the add-on repository is up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: github.event_name == 'schedule'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      with:
+        # Tags decide whether a version was released at all, which is what
+        # separates "the release broke" from "not released yet".
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Compare master's add-on version with the published one
+      env:
+        DISTRIBUTION_CONFIG: 'https://raw.githubusercontent.com/dougrathbone/cgateweb-homeassistant/main/cgateweb/config.yaml'
+      run: |
+        set -uo pipefail
+
+        read_version() {
+          grep -m1 -E '^version:' "$1" | sed -E 's/^version:[[:space:]]*"?([^"]+)"?[[:space:]]*$/\1/'
+        }
+
+        SOURCE_VERSION=$(read_version homeassistant-addon/config.yaml)
+        if [[ -z "${SOURCE_VERSION}" ]]; then
+          echo "::error::Could not read the version from homeassistant-addon/config.yaml."
+          exit 1
+        fi
+
+        if ! curl -fsSL --retry 3 --retry-all-errors --retry-delay 5 \
+          --max-time 60 -o published-config.yaml "${DISTRIBUTION_CONFIG}"; then
+          echo "::error::Could not fetch the published add-on config from the distribution repository."
+          exit 1
+        fi
+        PUBLISHED_VERSION=$(read_version published-config.yaml)
+        if [[ -z "${PUBLISHED_VERSION}" ]]; then
+          echo "::error::The published config.yaml has no readable version key."
+          exit 1
+        fi
+
+        echo "master:    ${SOURCE_VERSION}"
+        echo "published: ${PUBLISHED_VERSION}"
+
+        if [[ "${SOURCE_VERSION}" == "${PUBLISHED_VERSION}" ]]; then
+          echo "Add-on repository is serving ${PUBLISHED_VERSION}; nothing pending."
+          exit 0
+        fi
+
+        if git rev-parse -q --verify "refs/tags/v${SOURCE_VERSION}" >/dev/null; then
+          echo "::error::v${SOURCE_VERSION} is tagged but the add-on repository still serves ${PUBLISHED_VERSION}. The release did not land - check the newest 'Build and Deploy Home Assistant Addon' run and re-run it."
+          exit 1
+        fi
+
+        echo "::notice::master is at ${SOURCE_VERSION} and the add-on repository serves ${PUBLISHED_VERSION}. No v${SOURCE_VERSION} tag yet, so the release is still pending: push the tag to ship it."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ Two consequences worth knowing before touching it:
 
 After tagging, `hacs-distribution.yml` creates GitHub Releases on **both** the distribution repo and this source repo (notes from `homeassistant-addon/CHANGELOG.md`). You no longer need to backfill the source release by hand.
 
+**A tag is not a release.** The tag push re-runs the whole quality gate, so anything red there — including a test that only fails sometimes — stops the publish *after* the version has been tagged and the changelog written. The source repo then looks released while Supervisor still offers the previous version, and nothing tells you. That is how v1.34.0 was tagged and never reached a single Home Assistant. Two scheduled jobs in `ci.yml` now cover it: `flake-watch` repeats the unit suite on an unchanged master (on Node 20 and 22) so a nondeterministic test is found overnight instead of at a release, and `distribution-drift-check` compares master's `homeassistant-addon/config.yaml` version against the one the distribution repo is serving — it fails when the version is tagged but not published, and only notes it when the tag is still pending. After any release, confirm the newest `Build and Deploy Home Assistant Addon` run is green rather than assuming the tag was enough.
+
 ### Home Assistant Add-on config.yaml Rules
 
 When modifying `homeassistant-addon/config.yaml`, follow these rules to prevent upgrade failures:

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -16,6 +16,7 @@ If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.co
 - **The alarm panel entity now appears in Home Assistant.** Home Assistant rejected the read-only version of it, so installs without Security Panel Control had no panel at all.
 - **A C-Bus network whose interface keeps dropping no longer floods C-Gate.** Repeated network syncs now trigger at most one refresh a minute instead of one each, which had left every command failing.
 - **Failed C-Gate commands now say why.** A network with a dropped CNI or PCI link is named as the cause, and identical errors are counted rather than repeated thousands of times.
+- **Saving labels no longer refreshes discovery a second time on a busy system.**
 
 ## [1.34.0] - 2026-09-02
 

--- a/homeassistant-addon/CHANGELOG.md
+++ b/homeassistant-addon/CHANGELOG.md
@@ -18,6 +18,10 @@ If this add-on saves you time, you can [buy me a coffee](https://buymeacoffee.co
 - **Failed C-Gate commands now say why.** A network with a dropped CNI or PCI link is named as the cause, and identical errors are counted rather than repeated thousands of times.
 - **Saving labels no longer refreshes discovery a second time on a busy system.**
 
+### Changed
+
+- Internal: the nightly build repeats the unit tests to catch tests that only fail sometimes, and checks that the add-on repository is serving the released version.
+
 ## [1.34.0] - 2026-09-02
 
 ### Changed

--- a/src/labelLoader.js
+++ b/src/labelLoader.js
@@ -315,8 +315,19 @@ class LabelLoader extends EventEmitter {
         this._areas = new Map();
     }
 
+    /**
+     * Canonical form of everything a listener would act on, for deciding
+     * whether a reload actually changed anything.
+     * @returns {string}
+     * @private
+     */
+    _dataSignature() {
+        return JSON.stringify(this.getFullData());
+    }
+
     _onFileChanged() {
         const previousSize = this._labels.size;
+        const previousSignature = this._dataSignature();
         this.load({ keepOnError: true });
         if (this._lastLoadError) {
             // Backup tools (HA backup) briefly remove or replace the label
@@ -337,6 +348,19 @@ class LabelLoader extends EventEmitter {
             return;
         }
         this._reloadRetried = false;
+        // The grace window is checked when the OS delivers the watch event, so
+        // an event for our own save() that arrives later than the grace escapes
+        // it and reloads a file nobody edited. That happens whenever the event
+        // loop stalls for about a second - a busy Home Assistant host, or a
+        // loaded CI runner. Reloading identical data is harmless; telling every
+        // listener the labels changed is not, since it re-runs HA Discovery and
+        // pushes an SSE update for nothing. So the emit is gated on the data
+        // rather than on the clock, which also makes the grace a pure
+        // optimisation instead of the correctness mechanism.
+        if (this._dataSignature() === previousSignature) {
+            this.logger.debug('Label file reload produced no changes; not emitting labels-changed');
+            return;
+        }
         this.logger.info('Label file changed on disk, reloading...');
         this.logger.info(`Labels reloaded: ${previousSize} -> ${this._labels.size} labels`);
         this.emit('labels-changed', this.getLabelData());

--- a/tests/labelLoader.test.js
+++ b/tests/labelLoader.test.js
@@ -416,6 +416,20 @@ describe('LabelLoader', () => {
     });
 
     describe('watch / hot-reload', () => {
+        /**
+         * Wait for a real fs.watch event to have been delivered and debounced,
+         * giving up quietly after a margin no healthy run needs. Deliberately
+         * does not throw: the caller's assertion holds whether or not the
+         * watcher fired, and requiring it would just trade one timing
+         * dependency for another.
+         */
+        async function waitForWatcherReload(reloadSpy, timeoutMs = 2000) {
+            const deadline = Date.now() + timeoutMs;
+            while (reloadSpy.mock.calls.length === 0 && Date.now() < deadline) {
+                await new Promise((resolve) => setTimeout(resolve, 25));
+            }
+        }
+
         it('should emit labels-changed when the file is modified', (done) => {
             const data = { version: 1, labels: { '254/56/10': 'Original' } };
             fs.writeFileSync(labelFile, JSON.stringify(data));
@@ -437,11 +451,19 @@ describe('LabelLoader', () => {
             }, 100);
         }, 5000);
 
-        it('save() emits labels-changed exactly once even with the watcher running (no double-fire)', (done) => {
-            // The watcher's SELF_WRITE_GRACE_MS exists to prevent a SECOND
-            // labels-changed firing from the fs.watch callback after our own
-            // write. The FIRST emit comes from save() directly so the in-
-            // process listeners (HA Discovery refresh, web UI SSE) wake up.
+        it('save() emits labels-changed exactly once even with the watcher running (no double-fire)', async () => {
+            // The FIRST emit comes from save() directly, so the in-process
+            // listeners (HA Discovery refresh, web UI SSE) wake up. A SECOND
+            // one, from the watcher seeing our own write, must not follow.
+            //
+            // Nothing here may depend on when the OS delivers that watcher
+            // event. The previous version asserted 800ms into the 1000ms grace
+            // window on the theory that a later event could not have been
+            // processed yet - but the grace is checked when the event is
+            // delivered, not when the reload runs, so an event-loop stall of
+            // about a second let the delivery escape the grace and the
+            // assertion land after the resulting second emit. That is the flake
+            // that failed the v1.34.0 release.
             const data = { version: 1, labels: { '254/56/10': 'Init' } };
             fs.writeFileSync(labelFile, JSON.stringify(data));
 
@@ -451,22 +473,24 @@ describe('LabelLoader', () => {
 
             const handler = jest.fn();
             loader.on('labels-changed', handler);
+            const reloads = jest.spyOn(loader, '_onFileChanged');
 
             loader.save({ '254/56/10': 'Via Save' });
 
-            // Assert INSIDE the grace window (1000ms): the direct emit from
-            // save() is synchronous, and every watcher event arriving before
-            // this point is suppressed by SELF_WRITE_GRACE_MS by construction,
-            // so a second emit is impossible regardless of event-loop lag.
-            // Waiting longer than the grace (as this test used to) makes the
-            // outcome depend on watcher delivery timing on loaded CI runners.
-            setTimeout(() => {
-                expect(handler).toHaveBeenCalledTimes(1);
-                expect(handler.mock.calls[0][0].labels.get('254/56/10')).toBe('Via Save');
-                loader.unwatch();
-                done();
-            }, 800);
-        }, 5000);
+            // save() emits synchronously, before any watcher event can exist.
+            expect(handler).toHaveBeenCalledTimes(1);
+
+            // Then give the real watcher its chance. Not required to fire -
+            // whether the grace suppresses it or it reloads identical data
+            // afterwards, the count is one either way, and inotify is not
+            // guaranteed in every sandbox - so this waits for it rather than
+            // asserting on it.
+            await waitForWatcherReload(reloads);
+
+            expect(handler).toHaveBeenCalledTimes(1);
+            expect(handler.mock.calls[0][0].labels.get('254/56/10')).toBe('Via Save');
+            loader.unwatch();
+        }, 15000);
 
         it('should do nothing when no file path is configured', () => {
             const loader = new LabelLoader(null);
@@ -585,6 +609,21 @@ describe('LabelLoader', () => {
             expect(handler.mock.calls[1][0].labels.get('254/56/10')).toBe('After Grace');
         });
 
+        // The grace window is checked when the OS delivers the event, so a
+        // delivery slower than the grace escapes it. Reloading is then
+        // unavoidable; emitting is not.
+        it('does not emit when a reload finds the file unchanged', () => {
+            const handler = jest.fn();
+            loader.save({ '254/56/10': 'Via Save' });
+            loader.on('labels-changed', handler);
+
+            jest.advanceTimersByTime(GRACE_MS + 1);
+            watchListener('change', path.basename(labelFile));
+            jest.advanceTimersByTime(DEBOUNCE_MS);
+
+            expect(handler).not.toHaveBeenCalled();
+        });
+
         it('ignores watch events for unrelated filenames', () => {
             const onChanged = jest.spyOn(loader, '_onFileChanged');
             watchListener('change', 'other-file.json');
@@ -642,7 +681,7 @@ describe('reload robustness (transient file absence, e.g. HA backup)', () => {
         expect(handler).not.toHaveBeenCalled();
     });
 
-    it('recovers on the retry when the file comes back', () => {
+    it('recovers on the retry when the file comes back unchanged, without a spurious emit', () => {
         const loader = seedLoader({ '254/56/10': 'Kitchen' });
         const handler = jest.fn();
         loader.on('labels-changed', handler);
@@ -655,8 +694,30 @@ describe('reload robustness (transient file absence, e.g. HA backup)', () => {
         fs.renameSync(`${labelFile}.bak`, labelFile);
         jest.runOnlyPendingTimers();
 
+        // The labels were held in memory throughout and the file came back
+        // identical, so there is nothing for HA Discovery or the web UI to redo.
+        expect(loader.getLabelsObject()).toEqual({ '254/56/10': 'Kitchen' });
+        expect(handler).not.toHaveBeenCalled();
+        expect(loader._reloadRetried).toBe(false);
+    });
+
+    it('emits on the retry when the file comes back different', () => {
+        const loader = seedLoader({ '254/56/10': 'Kitchen' });
+        const handler = jest.fn();
+        loader.on('labels-changed', handler);
+
+        fs.renameSync(labelFile, `${labelFile}.bak`);
+        loader._onFileChanged();
+
+        // A restore puts back an edited copy
+        fs.writeFileSync(labelFile, JSON.stringify({
+            version: 1,
+            labels: { '254/56/10': 'Kitchen Restored' }
+        }));
+        jest.runOnlyPendingTimers();
+
         expect(handler).toHaveBeenCalledTimes(1);
-        expect(handler.mock.calls[0][0].labels.get('254/56/10')).toBe('Kitchen');
+        expect(handler.mock.calls[0][0].labels.get('254/56/10')).toBe('Kitchen Restored');
     });
 
     it('keeps current labels when the file is briefly unreadable (partial write)', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The v1.34.0 release never reached anyone. [The tag run](https://github.com/dougrathbone/cgateweb/actions/runs/33587233757) failed on one test — `LabelLoader › save() emits labels-changed exactly once even with the watcher running` — on Node 20 while passing on Node 22 for the same commit, so the publish jobs were skipped. The distribution repository is still serving `1.33.0` today, which is why the C-Bus and alarm-panel bugs from the last round were being hit on a version that no longer had them.

**Root cause, reproduced.** The label watcher suppresses the filesystem event for its own `save()` by comparing the delivery time against `labelWatchSelfWriteGraceMs` (1s). That check happens when the OS hands the event over, not when the reload runs, so an event loop that stalls for about a second lets the delivery land outside the grace: the file is reloaded and a second `labels-changed` goes out for a file nobody edited, re-running HA Discovery and pushing an SSE update for nothing. Twenty lines are enough to show it — `save()`, block the loop for 1.3s, and the queued event arrives past the grace and emits again:

```
emits right after save(): 1
emits after the delayed watcher event: 2
```

The test asserted 800ms into the grace window on the theory that a later event could not have been processed yet, so the same stall that produced the second emit also pushed its assertion past it. That is why it was red on one Node version and green on the other, hit twice within an hour (the tag and [a dependabot PR](https://github.com/dougrathbone/cgateweb/actions/runs/33587380456)), and never on a developer machine — I could not reproduce it in dozens of full-suite runs on either Node version here without stalling the loop by hand.

**Fix.** The watcher-driven reload now compares the loaded data against what is already in memory and only emits when it differs. The grace window becomes an optimisation rather than the correctness mechanism, so no amount of lag can produce a spurious emit — and users on a busy Home Assistant host stop getting a redundant discovery refresh every time they save labels. The repro script now prints `1` and `1`.

**Stopping this class of failure from surfacing at a release.** A flake is invisible on a push: the red run gets blamed on whatever change was in flight, a re-run turns it green, and nobody looks again. The first place it reliably bites is the tag, where the gate runs again — and by then the version is tagged and the changelog is published, so the repo looks released while Supervisor still offers the previous version, with nothing to say otherwise. Two scheduled jobs close that, for about two runner-minutes a day:

- `flake-watch` repeats the unit suite three times on an unchanged master, on Node 20 and 22. Node 20 is in the matrix deliberately — that is the only place this flake ever reproduced.
- `distribution-drift-check` compares master's add-on version against the version the distribution repository is serving. It **fails** when the version is tagged but not published (a release that broke, for any reason — a flaky test, an expired deploy token, or the GHCR visibility failure that killed v1.28.0) and only **notes** it when the tag is still pending, so the normal gap between a merge and a tag stays quiet. Verified both branches locally against the live distribution config: it reports "release pending" for the current state and fails when pointed at the v1.34.0 situation.

`CLAUDE.md` now states plainly that a tag is not a release, and to confirm the deploy run is green afterwards.

## Changes

- `src/labelLoader.js`: the watcher-driven reload emits `labels-changed` only when the data actually changed.
- `tests/labelLoader.test.js`: the real-watcher test asserts synchronously after `save()` and then waits for the watcher without requiring it to have fired; a fake-timer test covers a post-grace reload finding no changes; the HA-backup recovery test now asserts no spurious emit, with a new case for a file that comes back edited.
- `.github/workflows/ci.yml`: `flake-watch` and `distribution-drift-check`, both schedule-only.
- `CLAUDE.md`, `homeassistant-addon/CHANGELOG.md`: the release-verification note and two bullets under the still-unreleased 1.34.1 entry.

## Test plan

- [x] `npm test` passes (3060 tests, 95 suites), and three consecutive full runs on Node 20 as well as Node 22
- [x] `npm run lint`, `npm run typecheck` and `actionlint` pass
- [x] The double-fire repro fails on master and passes here
- [x] The drift-check script verified against the live distribution config in both the "pending" and "tagged but unpublished" states

## Checklist

- [x] Version stays 1.34.1 — it was never tagged, so these bullets join that entry rather than starting a new release
- [x] `CHANGELOG.md` updated
- [x] No sensitive data or credentials included

**To actually ship it:** merge this, then `git tag v1.34.1 && git push origin v1.34.1`. I deliberately did not tag the current master, because that commit still contains the flaky test and I cannot re-run a failed workflow from here — tagging after this lands means the release gate runs a deterministic suite.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-34c373d3-6b01-4ca5-b9c5-d62aab36d06b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-34c373d3-6b01-4ca5-b9c5-d62aab36d06b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

